### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     env:
       OS: ${{ matrix.os }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 - CLI: Upgrade to `click-aliases>=1.0.2`, fixing erroring out when no group aliases
   are specified.
 
+- Add support for Python 3.12
+
 
 ## 2023/10/10 0.0.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Adaptive Technologies",
   "Topic :: Communications",
   "Topic :: Database",


### PR DESCRIPTION
## About

Add Python 3.12 to the list of supported Python releases.

## References

- GH-63