### PR TITLE
CI: Run on Python 3.8 and 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.12"]
+        python-version: ["3.8", "3.12"]
 
     env:
       OS: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dynamic = [
 dependencies = [
   "boltons<24",
   "click<9",
-  "click-aliases<2,>=1.0.2",
+  "click-aliases<2,>=1.0.3",
   "colorama<1",
   "colorlog",
   "crash",


### PR DESCRIPTION
This is to verify both the minimum and maximum versions of Python to be supported. There are gaps in between, but c'est la view, it saves time and resources.