### PR TITLE
Add `import_csv_pandas` and `import_csv_dask` utility primitives

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         pip install "setuptools>=64" --upgrade
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[test,develop]
+        pip install --use-pep517 --prefer-binary --editable=.[io,test,develop]
 
     - name: Run linter and software tests
       run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ## Unreleased
 
 - Add SQL runner utility primitives to `io.sql` namespace
+- Add `import_csv_pandas` and `import_csv_dask` utility primitives
 
 
 ## 2023/11/06 v0.0.2

--- a/cratedb_toolkit/util/database.py
+++ b/cratedb_toolkit/util/database.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, Crate.io Inc.
 # Distributed under the terms of the AGPLv3 license, see LICENSE.
 import io
+import os
 import typing as t
 from pathlib import Path
 
@@ -227,8 +228,7 @@ class DatabaseAdapter:
         from crate.client.sqlalchemy.support import insert_bulk
 
         # Set a few defaults.
-        # TODO: Use amount of CPU cores instead?
-        npartitions = npartitions or 4
+        npartitions = npartitions or os.cpu_count()
 
         if progress:
             from dask.diagnostics import ProgressBar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ develop = [
 ]
 io = [
   "dask<=2023.10.1,>=2020",
-  "pandas<3,>=2",
+  "pandas<3,>=1",
 ]
 release = [
   "build<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,10 @@ develop = [
   "ruff==0.1.3",
   "validate-pyproject<0.16",
 ]
+io = [
+  "dask<=2023.10.1,>=2020",
+  "pandas<3,>=2",
+]
 release = [
   "build<2",
   "twine<5",

--- a/release/oci/Dockerfile
+++ b/release/oci/Dockerfile
@@ -21,7 +21,7 @@ COPY . /src
 
 # Install package.
 RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
-    pip install --use-pep517 --prefer-binary '/src'
+    pip install --use-pep517 --prefer-binary '/src[io]'
 
 # Uninstall Git again.
 RUN apt-get --yes remove --purge git && apt-get --yes autoremove

--- a/tests/io/test_import.py
+++ b/tests/io/test_import.py
@@ -1,0 +1,49 @@
+import pytest
+
+
+@pytest.fixture
+def dummy_csv(tmp_path):
+    """
+    Provide a dummy CSV file to the test cases.
+    """
+    csvfile = tmp_path / "dummy.csv"
+    csvfile.write_text("name,value\ntemperature,42.42\nhumidity,84.84")
+    return csvfile
+
+
+def test_import_csv_pandas(cratedb, dummy_csv):
+    """
+    Invoke convenience function `import_csv_pandas`, and verify database content.
+    """
+    result = cratedb.database.import_csv_pandas(filepath=dummy_csv, tablename="foobar")
+    assert result is None
+
+    cratedb.database.run_sql("REFRESH TABLE foobar;")
+    result = cratedb.database.run_sql("SELECT COUNT(*) FROM foobar;")
+    assert result == [(2,)]
+
+
+def test_import_csv_dask(cratedb, dummy_csv):
+    """
+    Invoke convenience function `import_csv_dask`, and verify database content.
+    """
+    result = cratedb.database.import_csv_dask(filepath=dummy_csv, tablename="foobar")
+    assert result is None
+
+    cratedb.database.run_sql("REFRESH TABLE foobar;")
+    result = cratedb.database.run_sql("SELECT COUNT(*) FROM foobar;")
+    assert result == [(2,)]
+
+
+def test_import_csv_dask_with_progressbar(cratedb, dummy_csv):
+    """
+    Invoke convenience function `import_csv_dask`, and verify database content.
+    This time, use `progress=True` to make Dask display a progress bar.
+    However, the code does not verify it.
+    """
+    result = cratedb.database.import_csv_dask(filepath=dummy_csv, tablename="foobar", progress=True)
+    assert result is None
+
+    cratedb.database.run_sql("REFRESH TABLE foobar;")
+    result = cratedb.database.run_sql("SELECT COUNT(*) FROM foobar;")
+    assert result == [(2,)]


### PR DESCRIPTION
## About

More yak shaving.


## Details

Similar to https://github.com/pyveci/pueblo/pull/12 and https://github.com/crate-workbench/cratedb-toolkit/pull/74, this patch adds generalized testing helper functions to avoid code duplication within the educational repository [cratedb-examples](https://github.com/crate/cratedb-examples), originally conceived at https://github.com/crate/cratedb-examples/commit/dd09e144ef0. We need those kinds of utility functions at many more spots, so we need to find canonical places to store them.

## Synopsis
```shell
pip install 'cratedb-toolkit[io]'
```
```python
from cratedb_toolkit.io.sql import DatabaseAdapter

# Define database connection.
cratedb = DatabaseAdapter(dburi="crate://crate@localhost:4200")

# Mangle data. You choose.
cratedb.import_csv_pandas(filepath="test.csv", tablename="foobar")
cratedb.import_csv_dask(filepath="test.csv", tablename="foobar")
```

## References
- https://github.com/crate/cratedb-examples/pull/64
- https://github.com/crate/cratedb-examples/pull/122

## Notes

Note that details on the interface may change while we go, specifically on the "naming things" / DWIM side of things. If you have any suggestions, feel free to add your voice. Right now, the main focus is to ship it, to be able to re-use it on behalf of Jupyter Notebooks we are currently publishing, in order to reduce boilerplate code within them.

/cc @karynzv, @marijaselakovic, @hlcianfagna, @hammerhead, @WalBeh, @andnig, @ckurze, @vvulf