### PR TITLE
InfluxDB: Add adapter to `influxio`, implementing `ctk load table influxdb2://...`

### DIFF
--- a/.github/workflows/influxdb.yml
+++ b/.github/workflows/influxdb.yml
@@ -1,10 +1,19 @@
 ---
-name: "Tests: Common"
+name: "Tests: InfluxDB"
 
 on:
-  pull_request: ~
+  pull_request:
+    branches: ~
+    paths:
+    - '.github/workflows/influxdb.yml'
+    - 'cratedb_toolkit/io/influxdb/**'
+    - 'pyproject.toml'
   push:
     branches: [ main ]
+    paths:
+    - '.github/workflows/influxdb.yml'
+    - 'cratedb_toolkit/io/influxdb/**'
+    - 'pyproject.toml'
 
   # Allow job to be triggered manually.
   workflow_dispatch:
@@ -27,23 +36,23 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.12"]
+        # TODO: yarl, dependency of influxio, is currently not available on Python 3.12.
+        #       https://github.com/aio-libs/yarl/pull/942
+        python-version: ["3.8", "3.11"]
+        influxdb-version: ["2.6", "2.7"]
 
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
+      INFLUXDB_VERSION: ${{ matrix.influxdb-version }}
       # Do not tear down Testcontainers
       TC_KEEPALIVE: true
 
-    # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
-    services:
-      cratedb:
-        image: crate/crate:nightly
-        ports:
-          - 4200:4200
-          - 5432:5432
-
-    name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
+    name: "
+    Python ${{ matrix.python-version }}, 
+    InfluxDB ${{ matrix.influxdb-version }}, 
+    OS ${{ matrix.os }}
+    "
     steps:
 
     - name: Acquire sources
@@ -65,7 +74,7 @@ jobs:
         pip install "setuptools>=64" --upgrade
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[io,test,develop]
+        pip install --use-pep517 --prefer-binary --editable=.[influxdb,io,test,develop]
 
     - name: Run linter and software tests
       run: |
@@ -75,7 +84,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
-        flags: main
+        flags: influxdb
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
         pip install "setuptools>=64" --upgrade
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[io,test,develop]
+        pip install --use-pep517 --prefer-binary --editable=.[io,influxdb,test,develop]
 
     - name: Run linter and software tests
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 __pycache__
 *.pyc
 dist
-.coverage
+.coverage*
 coverage.xml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Add SDK and CLI for CrateDB Cloud Data Import APIs
   `ctk load table ...`
 - Add `migr8` program from previous repository
+- InfluxDB: Add adapter for `influxio`
 
 
 ## 2023/11/06 v0.0.2

--- a/cratedb_toolkit/io/README.md
+++ b/cratedb_toolkit/io/README.md
@@ -65,4 +65,36 @@ ctk shell --command="SELECT * FROM data_weather LIMIT 10;" --format=json
 - Exercise data imports from AWS S3 and other Object Storage providers.
 
 
+## InfluxDB
+
+Using the adapter to [influxio], you can transfer data from InfluxDB to CrateDB.
+
+Import two data points into InfluxDB.
+```shell
+export INFLUX_ORG=example
+export INFLUX_TOKEN=token
+export INFLUX_BUCKET_NAME=testdrive
+export INFLUX_MEASUREMENT=demo
+influx bucket create
+influx write --precision=s "${INFLUX_MEASUREMENT},region=amazonas temperature=42.42,humidity=84.84 1556896326"
+influx write --precision=s "${INFLUX_MEASUREMENT},region=amazonas temperature=45.89,humidity=77.23,windspeed=5.4 1556896327"
+influx query "from(bucket:\"${INFLUX_BUCKET_NAME}\") |> range(start:-100y)"
+```
+
+Transfer data.
+```shell
+export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/testdrive/demo
+ctk load table influxdb2://example:token@localhost:8086/testdrive/demo
+crash --command "SELECT * FROM testdrive.demo;"
+```
+
+Todo: More convenient table querying.
+```shell
+export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/testdrive/demo
+ctk shell --command "SELECT * FROM testdrive.demo;"
+ctk show table "testdrive.demo"
+```
+
+
 [CrateDB Cloud]: https://console.cratedb.cloud/
+[influxio]: https://github.com/daq-tools/influxio

--- a/cratedb_toolkit/io/cli.py
+++ b/cratedb_toolkit/io/cli.py
@@ -146,10 +146,10 @@ def load_table_cratedb(sqlalchemy_url: str, resource_url: str):
     ctk load table influxdb2://example:token@localhost:8086/testdrive/demo
     """
     if resource_url.startswith("influxdb"):
-        from influxio.core import copy
+        from cratedb_toolkit.io.influxdb import influxdb_copy
 
         source_url = resource_url.replace("influxdb2", "http")
         target_url = sqlalchemy_url
-        copy(source_url, target_url, progress=True)
+        influxdb_copy(source_url, target_url, progress=True)
     else:
         raise NotImplementedError("Importing resource not implemented yet")

--- a/cratedb_toolkit/io/influxdb.py
+++ b/cratedb_toolkit/io/influxdb.py
@@ -1,0 +1,5 @@
+from influxio.core import copy
+
+
+def influxdb_copy(source_url, target_url, progress: bool = False):
+    copy(source_url, target_url, progress=progress)

--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 from testcontainers.core.config import MAX_TRIES
 from testcontainers.core.generic import DbContainer
-from testcontainers.core.waiting_utils import wait_for_logs
+from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
 
 from cratedb_toolkit.testing.testcontainers.util import KeepaliveContainer, asbool
 
@@ -95,7 +95,9 @@ class CrateDBContainer(KeepaliveContainer, DbContainer):
             port=self.port_to_expose,
         )
 
+    @wait_container_is_ready()
     def _connect(self):
         # TODO: Better use a network connectivity health check?
         #       In `testcontainers-java`, there is the `HttpWaitStrategy`.
+        # TODO: Provide a client instance.
         wait_for_logs(self, predicate="o.e.n.Node.*started", timeout=MAX_TRIES)

--- a/cratedb_toolkit/testing/testcontainers/influxdb2.py
+++ b/cratedb_toolkit/testing/testcontainers/influxdb2.py
@@ -1,0 +1,80 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from influxdb_client import InfluxDBClient
+from testcontainers.core.config import MAX_TRIES
+from testcontainers.core.generic import DbContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
+
+from cratedb_toolkit.testing.testcontainers.util import KeepaliveContainer
+
+
+class InfluxDB2Container(KeepaliveContainer, DbContainer):
+    """
+    InfluxDB database container.
+
+    - https://en.wikipedia.org/wiki/Influxdb
+
+    Example:
+
+        The example spins up an InfluxDB2 database instance.
+    """
+
+    ORGANIZATION = "example"
+    TOKEN = "token"  # noqa: S105
+
+    # TODO: Dual-port use with 8083+8086.
+    def __init__(
+        self,
+        # TODO: Use `influxdb:latest` by default?
+        image: str = "influxdb:2.7",
+        port: int = 8086,
+        dialect: str = "influxdb2",
+        **kwargs,
+    ) -> None:
+        super().__init__(image=image, **kwargs)
+
+        self._name = "testcontainers-influxdb"  # -{os.getpid()}
+
+        self.port_to_expose = port
+        self.dialect = dialect
+
+        self.with_exposed_ports(self.port_to_expose, 8083)
+
+        self.debug = False
+
+    def _configure(self) -> None:
+        self.with_env("DOCKER_INFLUXDB_INIT_MODE", "setup")
+        self.with_env("DOCKER_INFLUXDB_INIT_USERNAME", "admin")
+        self.with_env("DOCKER_INFLUXDB_INIT_PASSWORD", "secret1234")
+        self.with_env("DOCKER_INFLUXDB_INIT_ORG", self.ORGANIZATION)
+        self.with_env("DOCKER_INFLUXDB_INIT_BUCKET", "default")
+        self.with_env("DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", self.TOKEN)
+
+    def get_connection_url(self, host=None) -> str:
+        return super()._create_connection_url(
+            dialect="http",
+            username=self.ORGANIZATION,
+            password=self.TOKEN,
+            host=host,
+            port=self.port_to_expose,
+        )
+
+    @wait_container_is_ready()
+    def _connect(self) -> InfluxDBClient:
+        # TODO: Better use a network connectivity health check?
+        #       In `testcontainers-java`, there is the `HttpWaitStrategy`.
+        wait_for_logs(self, predicate="Listening.*tcp-listener.*8086", timeout=MAX_TRIES)
+        return InfluxDBClient(url=self.get_connection_url(), org=self.ORGANIZATION, token=self.TOKEN, debug=self.debug)
+
+    def get_connection_client(self) -> InfluxDBClient:
+        return self._connect()

--- a/cratedb_toolkit/testing/testcontainers/influxdb2.py
+++ b/cratedb_toolkit/testing/testcontainers/influxdb2.py
@@ -10,6 +10,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import os
+
 from influxdb_client import InfluxDBClient
 from testcontainers.core.config import MAX_TRIES
 from testcontainers.core.generic import DbContainer
@@ -29,14 +31,15 @@ class InfluxDB2Container(KeepaliveContainer, DbContainer):
         The example spins up an InfluxDB2 database instance.
     """
 
+    INFLUXDB_VERSION = os.environ.get("INFLUXDB_VERSION", "latest")
+
     ORGANIZATION = "example"
     TOKEN = "token"  # noqa: S105
 
     # TODO: Dual-port use with 8083+8086.
     def __init__(
         self,
-        # TODO: Use `influxdb:latest` by default?
-        image: str = "influxdb:2.7",
+        image: str = f"influxdb:{INFLUXDB_VERSION}",
         port: int = 8086,
         dialect: str = "influxdb2",
         **kwargs,

--- a/cratedb_toolkit/util/database.py
+++ b/cratedb_toolkit/util/database.py
@@ -92,6 +92,14 @@ class DatabaseAdapter:
         except Exception:
             return False
 
+    def refresh_table(self, tablename_full: str):
+        """
+        Run a `REFRESH TABLE ...` command.
+        """
+        sql = f"REFRESH TABLE {tablename_full};"  # noqa: S608
+        self.run_sql(sql=sql)
+        return True
+
     def drop_repository(self, name: str):
         """
         Drop snapshot repository.

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -36,6 +36,10 @@
 - UX: Make `ctk list-jobs` respect `"status": "SUCCEEDED"` etc.
 - UX: Improve textual report from `ctk load table`
 - UX: Accept alias `--format {jsonl,ndjson}` for `--format json_row` 
+- Catch recursion errors:
+  ```
+  CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/
+  ```
 
 ## Iteration +3
 - CI: Nightly builds, to verify regressions on CrateDB

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ develop = [
   "ruff==0.1.3",
   "validate-pyproject<0.16",
 ]
+influxdb = [
+  "influxio==0.1.1",
+]
 io = [
   "cr8",
   "dask<=2023.10.1,>=2020",

--- a/tests/io/influxdb/conftest.py
+++ b/tests/io/influxdb/conftest.py
@@ -1,0 +1,66 @@
+import logging
+
+import pytest
+from influxdb_client import InfluxDBClient
+
+from cratedb_toolkit.testing.testcontainers.influxdb2 import InfluxDB2Container
+
+logger = logging.getLogger(__name__)
+
+
+# Define buckets to be deleted before running each test case.
+RESET_BUCKETS = [
+    "testdrive",
+]
+
+
+class InfluxDB2Fixture:
+    """
+    A little helper wrapping Testcontainer's `InfluxDB2Container`.
+    """
+
+    def __init__(self):
+        self.container = None
+        self.client: InfluxDBClient = None
+        self.setup()
+
+    def setup(self):
+        # TODO: Make image name configurable.
+        self.container = InfluxDB2Container()
+        self.container.start()
+        self.client = self.container.get_connection_client()
+
+    def finalize(self):
+        self.container.stop()
+
+    def reset(self):
+        """
+        Delete all buckets used for testing.
+        """
+        for bucket_name in RESET_BUCKETS:
+            bucket = self.client.buckets_api().find_bucket_by_name(bucket_name)
+            if bucket is not None:
+                self.client.buckets_api().delete_bucket(bucket)
+
+    def get_connection_url(self, *args, **kwargs):
+        return self.container.get_connection_url(*args, **kwargs)
+
+
+@pytest.fixture(scope="session")
+def influxdb_service():
+    """
+    Provide an InfluxDB service instance to the test suite.
+    """
+    db = InfluxDB2Fixture()
+    db.reset()
+    yield db
+    db.finalize()
+
+
+@pytest.fixture(scope="function")
+def influxdb(influxdb_service):
+    """
+    Provide a fresh canvas to each test case invocation, by resetting database content.
+    """
+    influxdb_service.reset()
+    yield influxdb_service

--- a/tests/io/influxdb/conftest.py
+++ b/tests/io/influxdb/conftest.py
@@ -1,9 +1,6 @@
 import logging
 
 import pytest
-from influxdb_client import InfluxDBClient
-
-from cratedb_toolkit.testing.testcontainers.influxdb2 import InfluxDB2Container
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +17,16 @@ class InfluxDB2Fixture:
     """
 
     def __init__(self):
+        from influxdb_client import InfluxDBClient
+
         self.container = None
         self.client: InfluxDBClient = None
         self.setup()
 
     def setup(self):
         # TODO: Make image name configurable.
+        from cratedb_toolkit.testing.testcontainers.influxdb2 import InfluxDB2Container
+
         self.container = InfluxDB2Container()
         self.container.start()
         self.client = self.container.get_connection_client()

--- a/tests/io/influxdb/test_cli.py
+++ b/tests/io/influxdb/test_cli.py
@@ -1,3 +1,11 @@
+# ruff: noqa: E402
+import pytest
+
+pytest.importorskip("influxio", reason="Skipping InfluxDB tests because 'influxio' package is not installed")
+pytest.importorskip(
+    "influxdb_client", reason="Skipping InfluxDB tests because 'influxdb-client' package is not installed"
+)
+
 from click.testing import CliRunner
 from influxio.model import InfluxDbAdapter
 from influxio.testdata import DataFrameFactory

--- a/tests/io/influxdb/test_cli.py
+++ b/tests/io/influxdb/test_cli.py
@@ -1,0 +1,35 @@
+from click.testing import CliRunner
+from influxio.model import InfluxDbAdapter
+from influxio.testdata import DataFrameFactory
+
+from cratedb_toolkit.cli import cli
+
+
+def test_influxdb2_load_table(caplog, cratedb, influxdb):
+    """
+    CLI test: Invoke `ctk load table`.
+    """
+    cratedb_url = f"{cratedb.get_connection_url()}/testdrive/demo"
+    influxdb_url = f"{influxdb.get_connection_url()}/testdrive/demo"
+
+    # Populate source database with a few records worth of data.
+    adapter = InfluxDbAdapter.from_url(influxdb_url)
+    adapter.ensure_bucket()
+    dff = DataFrameFactory(rows=42)
+    df = dff.make("dateindex")
+    adapter.write_df(df)
+
+    # Run transfer command.
+    runner = CliRunner(env={"CRATEDB_SQLALCHEMY_URL": cratedb_url})
+    influxdb_url = influxdb_url.replace("http://", "influxdb2://")
+    result = runner.invoke(
+        cli,
+        args=f"load table {influxdb_url}",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Verify data in target database.
+    assert cratedb.database.table_exists("testdrive.demo") is True
+    assert cratedb.database.refresh_table("testdrive.demo") is True
+    assert cratedb.database.count_records("testdrive.demo") == 42


### PR DESCRIPTION
## About

This patch adds an adapter to the [influxio](https://pypi.org/project/influxio/) package, to facilitate data transfers from [InfluxDB v2](https://docs.influxdata.com/influxdb/v2/) and [InfluxDB line protocol](ILP).

## Synopsis

```shell
# Define target to be CrateDB schema=testdrive, table=demo.
export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/testdrive/demo

# Load data from organization=example, token=token, bucket=testdrive, measurement=demo.
ctk load table influxdb2://example:token@localhost:8086/testdrive/demo

# Verify data has been transferred.
crash --command "SELECT * FROM testdrive.demo;"
```

[InfluxDB line protocol]: https://docs.influxdata.com/influxdb/latest/reference/syntax/line-protocol/
