### PR TITLE
Testing: Generalize `KeepaliveContainer` from `CrateDBContainer`

### DIFF
--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -55,8 +55,7 @@ class CrateDBContainer(KeepaliveContainer, DbContainer):
     # TODO: Dual-port use with 4200+5432.
     def __init__(
         self,
-        # TODO: Use `crate/crate:nightly` by default?
-        image: str = "crate:latest",
+        image: str = "crate/crate:nightly",
         port: int = 4200,
         user: Optional[str] = None,
         password: Optional[str] = None,


### PR DESCRIPTION
## About

Add generalized `KeepaliveContainer` for efficient use of Testcontainers. It will give all containers the ability to honor `TC_KEEPALIVE=true`, i.e. not shutting down the container after running the test suite. This significantly improves cycle speed.

## Details

This generalization to the Testcontainers infrastructure is needed to bring in two subsequent patches, because both will rely on it.

- GH-76
- GH-77

Because both will use this very code to run their test cases, I will not bother to add dedicated test cases for the infrastructure code.