### PR TITLE
MongoDB: Improve UX by using `ctk load table mongodb://...`

### DIFF
--- a/.github/workflows/influxdb.yml
+++ b/.github/workflows/influxdb.yml
@@ -74,7 +74,7 @@ jobs:
         pip install "setuptools>=64" --upgrade
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[influxdb,io,test,develop]
+        pip install --use-pep517 --prefer-binary --editable=.[influxdb,test,develop]
 
     - name: Run linter and software tests
       run: |

--- a/.github/workflows/influxdb.yml
+++ b/.github/workflows/influxdb.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Run linter and software tests
       run: |
-        poe check
+        pytest -m influxdb
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -36,8 +36,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.12"]
-        mongodb-version: ["2", "3", "4", "5", "6", "7"]
+        python-version: ["3.8", "3.11"]
+        mongodb-version: ["3", "4", "5", "6", "7"]
 
     env:
       OS: ${{ matrix.os }}
@@ -69,6 +69,11 @@ jobs:
 
         # Install package in editable mode.
         pip install --use-pep517 --prefer-binary --editable=.[mongodb,test,develop]
+
+    - name: Downgrade pymongo on MongoDB 2
+      if: matrix.mongodb-version == '2'
+      run: |
+        pip install 'pymongo<4'
 
     - name: Run linter and software tests
       run: |

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Run linter and software tests
       run: |
-        poe check
+        pytest -m mongodb
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -68,7 +68,7 @@ jobs:
         pip install "setuptools>=64" --upgrade
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[io,test,develop]
+        pip install --use-pep517 --prefer-binary --editable=.[mongodb,test,develop]
 
     - name: Run linter and software tests
       run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
   `ctk load table ...`
 - Add `migr8` program from previous repository
 - InfluxDB: Add adapter for `influxio`
+- MongoDB: Add `migr8` program from previous repository
+- MongoDB: Improve UX by using `ctk load table mongodb://...`
 
 
 ## 2023/11/06 v0.0.2

--- a/cratedb_toolkit/io/README.md
+++ b/cratedb_toolkit/io/README.md
@@ -96,5 +96,45 @@ ctk show table "testdrive.demo"
 ```
 
 
+## MongoDB
+
+Using the MongoDB subsystem, you can transfer data from MongoDB to CrateDB.
+
+Import two data points into MongoDB.
+```shell
+mongosh mongodb://localhost:27017/testdrive <<EOF
+db.demo.remove({})
+db.demo.insertMany([
+  {
+    timestamp: new Date(1556896326),
+    region: "amazonas",
+    temperature: 42.42,
+    humidity: 84.84,
+  },
+  {
+    timestamp: new Date(1556896327),
+    region: "amazonas",
+    temperature: 45.89,
+    humidity: 77.23,
+    windspeed: 5.4,
+  },
+])
+db.demo.find({})
+EOF
+```
+
+Todo: Use `mongoimport`.
+```shell
+mongoimport --uri 'mongodb+srv://MYUSERNAME:SECRETPASSWORD@mycluster-ABCDE.azure.mongodb.net/test?retryWrites=true&w=majority'
+```
+
+Transfer data.
+```shell
+export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/testdrive/demo
+ctk load table mongodb://localhost:27017/testdrive/demo
+crash --command "SELECT * FROM testdrive.demo;"
+```
+
+
 [CrateDB Cloud]: https://console.cratedb.cloud/
 [influxio]: https://github.com/daq-tools/influxio

--- a/cratedb_toolkit/io/influxdb.py
+++ b/cratedb_toolkit/io/influxdb.py
@@ -1,5 +1,17 @@
+import logging
+
 from influxio.core import copy
+
+logger = logging.getLogger(__name__)
 
 
 def influxdb_copy(source_url, target_url, progress: bool = False):
+    """
+    Synopsis
+    --------
+    export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/testdrive/demo
+    ctk load table influxdb2://example:token@localhost:8086/testdrive/demo
+    """
+    logger.info("Running InfluxDB copy")
     copy(source_url, target_url, progress=progress)
+    return True

--- a/cratedb_toolkit/io/mongodb/README.md
+++ b/cratedb_toolkit/io/mongodb/README.md
@@ -3,6 +3,9 @@
 A utility program, called `migr8`, supporting data migrations
 between MongoDB and CrateDB.
 
+A one-stop command `ctk load table mongodb://...`, wrapping the `migr8`
+steps into a complete pipeline, to facilitate convenient data transfers.
+
 
 ## About
 
@@ -32,21 +35,39 @@ client driver library to version 3, like `pip install 'pymongo<4'`.
 
 Use `pip` to install the package from PyPI.
 ```shell
-pip install --upgrade 'cratedb-toolkit[io]'
+pip install --upgrade 'cratedb-toolkit[mongodb]'
 ```
 
 To verify if the installation worked, invoke:
 ```shell
-migr8 --version
-migr8 --help
+ctk --version
 ```
 
 
 ## Usage
 
+`ctk load table` is your one-stop command to populate a CrateDB table from a
+MongoDB collection.
+
+```shell
+export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/testdrive/demo
+ctk load table mongodb://localhost:27017/testdrive/demo
+```
+
+It will run `extract` and `translate` to gather the SQL DDL schema, and will
+invoke `export` and `cr8` to actually transfer data.
+
+
+## Usage for `migr8`
+
 The program `migr8` offers three subcommands (`extract`, `translate`, `export`),
 to conclude data transfers from MongoDB to CrateDB. Please read this section
 carefully to learn how they can be used successfully.
+
+```shell
+migr8 --version
+migr8 --help
+```
 
 ### Schema Extraction
 

--- a/cratedb_toolkit/io/mongodb/api.py
+++ b/cratedb_toolkit/io/mongodb/api.py
@@ -1,0 +1,70 @@
+import argparse
+import logging
+
+from cratedb_toolkit.io.mongodb.core import export, extract, translate
+from cratedb_toolkit.model import DatabaseAddress
+from cratedb_toolkit.util.cr8 import cr8_insert_json
+from cratedb_toolkit.util.database import DatabaseAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def mongodb_copy(source_url, target_url, progress: bool = False):
+    """
+    Synopsis
+    --------
+    export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/testdrive/demo
+    ctk load table mongodb://localhost:27017/testdrive/demo
+
+    Backlog
+    -------
+    TODO: Run on multiple collections.
+    TODO: Run on the whole database.
+    TODO: Accept parameters like `if_exists="append,replace"`.
+    TODO: Propagate parameters like `scan="full"`.
+    TODO: Handle timestamp precision(s)?
+    """
+    logger.info("Running MongoDB copy")
+
+    # Decode database URL.
+    mongodb_address = DatabaseAddress.from_string(source_url)
+    mongodb_uri, mongodb_collection_address = mongodb_address.decode()
+    mongodb_database = mongodb_collection_address.schema
+    mongodb_collection = mongodb_collection_address.table
+
+    # 1. Extract schema from MongoDB collection.
+    logger.info(f"Extracting schema from MongoDB: {mongodb_database}.{mongodb_collection}")
+    extract_args = argparse.Namespace(
+        url=str(mongodb_uri), database=mongodb_database, collection=mongodb_collection, scan="full"
+    )
+    mongodb_schema = extract(extract_args)
+    count = mongodb_schema[mongodb_collection]["count"]
+    if not count > 0:
+        logger.error(f"No results when extracting schema from MongoDB: {mongodb_database}.{mongodb_collection}")
+        return False
+
+    # 2. Translate schema to SQL DDL.
+    cratedb_address = DatabaseAddress.from_string(target_url)
+    cratedb_uri, cratedb_table_address = cratedb_address.decode()
+    ddl = translate(mongodb_schema, schemaname=cratedb_table_address.schema)
+
+    # 3. Load schema SQL DDL into CrateDB.
+    cratedb = DatabaseAdapter(dburi=str(cratedb_uri))
+    for collection, query in ddl.items():
+        logger.info(f"Creating table for collection '{collection}': {query}")
+        cratedb.run_sql(query)
+
+    # 4. Transfer data to CrateDB.
+    """
+    migr8 export --host localhost --port 27017 --database test_db --collection test | \
+        cr8 insert-json --hosts localhost:4200 --table test
+    """
+    logger.info(
+        f"Transferring data from MongoDB to CrateDB: "
+        f"source={mongodb_collection_address.fullname}, target={cratedb_table_address.fullname}"
+    )
+    export_args = argparse.Namespace(url=str(mongodb_uri), database=mongodb_database, collection=mongodb_collection)
+    buffer = export(export_args)
+    cr8_insert_json(infile=buffer, hosts=cratedb_address.httpuri, table=cratedb_table_address.fullname)
+
+    return True

--- a/cratedb_toolkit/io/mongodb/cli.py
+++ b/cratedb_toolkit/io/mongodb/cli.py
@@ -1,18 +1,15 @@
 import argparse
 import json
 
-import pymongo
 import rich
-from bson.raw_bson import RawBSONDocument
 
 from cratedb_toolkit import __version__
-from cratedb_toolkit.io.mongodb.core import extract, translate
-
-from .export import export
+from cratedb_toolkit.io.mongodb.core import export, extract, translate
 
 
 def extract_parser(subargs):
     parser = subargs.add_parser("extract", help="Extract a schema from a MongoDB database")
+    parser.add_argument("--url", default="mongodb://localhost:27017", help="MongoDB URL")
     parser.add_argument("--host", default="localhost", help="MongoDB host")
     parser.add_argument("--port", default=27017, help="MongoDB port")
     parser.add_argument("--database", required=True, help="MongoDB database")
@@ -35,6 +32,7 @@ def translate_parser(subargs):
 
 def export_parser(subargs):
     parser = subargs.add_parser("export", help="Export a MongoDB collection as plain JSON")
+    parser.add_argument("--url", default="mongodb://localhost:27017", help="MongoDB URL")
     parser.add_argument("--collection", required=True)
     parser.add_argument("--host", default="localhost", help="MongoDB host")
     parser.add_argument("--port", default=27017, help="MongoDB port")
@@ -80,12 +78,11 @@ def translate_from_file(args):
 
 
 def export_to_stdout(args):
-    client = pymongo.MongoClient(args.host, int(args.port), document_class=RawBSONDocument)
-    db = client[args.database]
-    export(db[args.collection])
+    export(args)
 
 
 def main():
+    rich.print("\n[green bold]MongoDB[/green bold] -> [blue bold]CrateDB[/blue bold] Exporter :: Schema Extractor\n\n")
     args = get_args()
     if args.command == "extract":
         extract_to_file(args)

--- a/cratedb_toolkit/io/mongodb/extract.py
+++ b/cratedb_toolkit/io/mongodb/extract.py
@@ -64,6 +64,8 @@ An example schema may look like:
 }
 """
 
+import typing as t
+
 import bson
 from pymongo.collection import Collection
 from rich import progress
@@ -77,7 +79,7 @@ progressbar = progress.Progress(
 )
 
 
-def extract_schema_from_collection(collection: Collection, partial: bool):
+def extract_schema_from_collection(collection: Collection, partial: bool) -> t.Dict[str, t.Any]:
     """
     Extract a schema definition from a collection.
 

--- a/cratedb_toolkit/io/mongodb/translate.py
+++ b/cratedb_toolkit/io/mongodb/translate.py
@@ -45,7 +45,7 @@ TYPES = {
 }
 
 BASE = """
-CREATE TABLE IF NOT EXISTS "doc"."{table}" (\n{columns}\n);
+CREATE TABLE IF NOT EXISTS "{schema}"."{table}" (\n{columns}\n);
 """
 
 COLUMN = '"{column_name}" {type}'
@@ -143,13 +143,14 @@ def indent_sql(query: str) -> str:
     return "\n".join(lines)
 
 
-def translate(schemas):
+def translate(schemas, schemaname: str = None):
     """
     Translate a schema definition for a set of MongoDB collection schemas.
 
     This results in a set of CrateDB compatible CREATE TABLE expressions
     corresponding to the set of MongoDB collection schemas.
     """
+    schemaname = schemaname or "doc"
 
     tables = list(schemas.keys())
     sql_queries = {}
@@ -162,5 +163,7 @@ def translate(schemas):
                 columns.append((COLUMN.format(column_name=fieldname, type=sql_type), comment))
 
         columns_definition = get_columns_definition(columns)
-        sql_queries[tablename] = indent_sql(BASE.format(table=tablename, columns=",\n".join(columns_definition)))
+        sql_queries[tablename] = indent_sql(
+            BASE.format(schema=schemaname, table=tablename, columns=",\n".join(columns_definition))
+        )
     return sql_queries

--- a/cratedb_toolkit/io/mongodb/util.py
+++ b/cratedb_toolkit/io/mongodb/util.py
@@ -1,0 +1,23 @@
+import re
+
+
+def parse_input_numbers(s: str):
+    """
+    Parse an input string for numbers and ranges.
+
+    Supports strings like '0 1 2', '0, 1, 2' as well as ranges such as
+    '0-2'.
+    """
+
+    options: list = []
+    for option in re.split(", | ", s):
+        match = re.search(r"(\d+)-(\d+)", option)
+        if match:
+            lower, upper = sorted([match.group(1), match.group(2)])
+            options = options + list(range(int(lower), int(upper) + 1))
+        else:
+            try:
+                options.append(int(option))
+            except ValueError:
+                pass
+    return options

--- a/cratedb_toolkit/model.py
+++ b/cratedb_toolkit/model.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 
 from boltons.urlutils import URL
 
+from cratedb_toolkit.util.database import decode_database_table
+
 
 @dataclasses.dataclass
 class DatabaseAddress:
@@ -17,16 +19,40 @@ class DatabaseAddress:
     @classmethod
     def from_string(cls, url):
         """
-        Factory method to create an instance from a URI in string format.
+        Factory method to create an instance from an SQLAlchemy database URL in string format.
         """
         return cls(uri=URL(url))
 
+    @classmethod
+    def from_httpuri(cls, url):
+        """
+        Factory method to create an instance from an HTTP URL in string format.
+        """
+        uri = URL(url)
+        if uri.scheme == "https":
+            uri.query_params["ssl"] = "true"
+        uri.scheme = "crate"
+        return cls(uri=uri)
+
     @property
-    def dburi(self):
+    def dburi(self) -> str:
         """
         Return a string representation of the database URI.
         """
         return str(self.uri)
+
+    @property
+    def httpuri(self) -> str:
+        """
+        Return the `http(s)://` variant of the database URI.
+        """
+        uri = deepcopy(self.uri)
+        uri.scheme = "http"
+        if "ssl" in uri.query_params:
+            if uri.query_params["ssl"]:
+                uri.scheme = "https"
+            del uri.query_params["ssl"]
+        return str(uri)
 
     @property
     def safe(self):
@@ -37,6 +63,15 @@ class DatabaseAddress:
         uri = deepcopy(self.uri)
         uri.password = "REDACTED"  # noqa: S105
         return str(uri)
+
+    def decode(self) -> t.Tuple[URL, "TableAddress"]:
+        """
+        Decode database and table names, and sanitize database URI.
+        """
+        database, table = decode_database_table(self.dburi)
+        uri = deepcopy(self.uri)
+        uri.path = ""
+        return uri, TableAddress(database, table)
 
 
 @dataclasses.dataclass

--- a/cratedb_toolkit/testing/testcontainers/mongodb.py
+++ b/cratedb_toolkit/testing/testcontainers/mongodb.py
@@ -38,3 +38,4 @@ class MongoDbContainerWithKeepalive(KeepaliveContainer, MongoDbContainer):
         **kwargs,
     ) -> None:
         super().__init__(image=image, **kwargs)
+        self.with_name("testcontainers-mongodb")

--- a/cratedb_toolkit/testing/testcontainers/util.py
+++ b/cratedb_toolkit/testing/testcontainers/util.py
@@ -99,6 +99,8 @@ class KeepaliveContainer(DockerContainer):
         containers = docker_client.client.api.containers(all=True, filters={"name": self._name})
 
         if not containers:
+            logger.info(f"Pulling image: {self.image}")
+            docker_client.client.images.pull(self.image)
             logger.info(f"Creating container from image: {self.image}")
             self._container = docker_client.run(
                 self.image,

--- a/cratedb_toolkit/util/cr8.py
+++ b/cratedb_toolkit/util/cr8.py
@@ -1,0 +1,8 @@
+import typing as t
+from pathlib import Path
+
+from cr8.insert_json import insert_json
+
+
+def cr8_insert_json(infile: t.Union[str, Path, t.IO[t.Any]], hosts: str, table: str):
+    return insert_json(table=table, bulk_size=5_000, hosts=hosts, infile=infile, output_fmt="json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,11 +92,13 @@ dependencies = [
   "crate[sqlalchemy]>=0.34",
   "croud==1.8",
   'importlib-metadata; python_version <= "3.7"',
-  "rich<14,>=3.3.2",
   "sqlalchemy>=2",
   "sqlparse<0.5",
 ]
 [project.optional-dependencies]
+all = [
+  "cratedb-toolkit[influxdb,io,mongodb]",
+]
 develop = [
   "black<24",
   "mypy==1.6.1",
@@ -111,16 +113,21 @@ influxdb = [
 io = [
   "cr8",
   "dask<=2023.10.1,>=2020",
-  "orjson<4,>=3.3.1",
   "pandas<3,>=1",
+]
+mongodb = [
+  "cr8",
+  "orjson<4,>=3.3.1",
   "pymongo<5,>=3.10.1",
   "python-bsonjs<0.4",
+  "rich<14,>=3.3.2",
 ]
 release = [
   "build<2",
   "twine<5",
 ]
 test = [
+  "pueblo[dataframe]@ git+https://github.com/pyveci/pueblo.git@develop",
   "pytest<8",
   "pytest-cov<5",
   "pytest-mock<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,8 @@ testpaths = [
 xfail_strict = true
 markers = [
   "examples",
+  "influxdb",
+  "mongodb",
   "slow",
 ]
 

--- a/release/oci/Dockerfile
+++ b/release/oci/Dockerfile
@@ -21,7 +21,7 @@ COPY . /src
 
 # Install package.
 RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
-    pip install --use-pep517 --prefer-binary '/src[io]'
+    pip install --use-pep517 --prefer-binary '/src[influxdb,io,mongodb]'
 
 # Uninstall Git again.
 RUN apt-get --yes remove --purge git && apt-get --yes autoremove

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,8 @@ RESET_TABLES = [
     f'"{TESTDRIVE_DATA_SCHEMA}"."foobar"',
     f'"{TESTDRIVE_DATA_SCHEMA}"."foobar_unique_single"',
     f'"{TESTDRIVE_DATA_SCHEMA}"."foobar_unique_composite"',
+    # cratedb_toolkit.io.{influxdb,mongodb}
+    '"testdrive"."demo"',
 ]
 
 

--- a/tests/io/influxdb/test_cli.py
+++ b/tests/io/influxdb/test_cli.py
@@ -5,6 +5,8 @@ from pueblo.testing.dataframe import DataFrameFactory
 
 from cratedb_toolkit.cli import cli
 
+pytestmark = pytest.mark.influxdb
+
 pytest.importorskip("influxio", reason="Skipping InfluxDB tests because 'influxio' package is not installed")
 pytest.importorskip(
     "influxdb_client", reason="Skipping InfluxDB tests because 'influxdb-client' package is not installed"

--- a/tests/io/influxdb/test_cli.py
+++ b/tests/io/influxdb/test_cli.py
@@ -1,30 +1,32 @@
 # ruff: noqa: E402
 import pytest
+from click.testing import CliRunner
+from pueblo.testing.dataframe import DataFrameFactory
+
+from cratedb_toolkit.cli import cli
 
 pytest.importorskip("influxio", reason="Skipping InfluxDB tests because 'influxio' package is not installed")
 pytest.importorskip(
     "influxdb_client", reason="Skipping InfluxDB tests because 'influxdb-client' package is not installed"
 )
 
-from click.testing import CliRunner
 from influxio.model import InfluxDbAdapter
-from influxio.testdata import DataFrameFactory
-
-from cratedb_toolkit.cli import cli
 
 
 def test_influxdb2_load_table(caplog, cratedb, influxdb):
     """
-    CLI test: Invoke `ctk load table`.
+    CLI test: Invoke `ctk load table` for InfluxDB.
     """
     cratedb_url = f"{cratedb.get_connection_url()}/testdrive/demo"
     influxdb_url = f"{influxdb.get_connection_url()}/testdrive/demo"
 
-    # Populate source database with a few records worth of data.
-    adapter = InfluxDbAdapter.from_url(influxdb_url)
-    adapter.ensure_bucket()
+    # Create sample dataset with a few records worth of data.
     dff = DataFrameFactory(rows=42)
     df = dff.make("dateindex")
+
+    # Populate source database.
+    adapter = InfluxDbAdapter.from_url(influxdb_url)
+    adapter.ensure_bucket()
     adapter.write_df(df)
 
     # Run transfer command.

--- a/tests/io/mongodb/conftest.py
+++ b/tests/io/mongodb/conftest.py
@@ -1,0 +1,68 @@
+import logging
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+# Define databases to be deleted before running each test case.
+RESET_DATABASES = [
+    "testdrive",
+]
+
+
+class MongoDBFixture:
+    """
+    A little helper wrapping Testcontainer's `MongoDbContainer`.
+    """
+
+    def __init__(self):
+        from pymongo import MongoClient
+
+        self.container = None
+        self.client: MongoClient = None
+        self.setup()
+
+    def setup(self):
+        # TODO: Make image name configurable.
+        from cratedb_toolkit.testing.testcontainers.mongodb import MongoDbContainerWithKeepalive
+
+        self.container = MongoDbContainerWithKeepalive()
+        self.container.start()
+        self.client = self.container.get_connection_client()
+
+    def finalize(self):
+        self.container.stop()
+
+    def reset(self):
+        """
+        Drop all databases used for testing.
+        """
+        for database_name in RESET_DATABASES:
+            self.client.drop_database(database_name)
+
+    def get_connection_url(self):
+        return self.container.get_connection_url()
+
+    def get_connection_client(self):
+        return self.container.get_connection_client()
+
+
+@pytest.fixture(scope="session")
+def mongodb_service():
+    """
+    Provide an MongoDB service instance to the test suite.
+    """
+    db = MongoDBFixture()
+    db.reset()
+    yield db
+    db.finalize()
+
+
+@pytest.fixture(scope="function")
+def mongodb(mongodb_service):
+    """
+    Provide a fresh canvas to each test case invocation, by resetting database content.
+    """
+    mongodb_service.reset()
+    yield mongodb_service

--- a/tests/io/mongodb/test_cli.py
+++ b/tests/io/mongodb/test_cli.py
@@ -6,7 +6,10 @@ from pueblo.testing.dataframe import DataFrameFactory
 
 from cratedb_toolkit.cli import cli
 
+pytestmark = pytest.mark.mongodb
+
 pymongo = pytest.importorskip("pymongo", reason="Skipping tests because pymongo is not installed")
+pytest.importorskip("rich", reason="Skipping tests because rich is not installed")
 
 
 def test_version():

--- a/tests/io/mongodb/test_cli.py
+++ b/tests/io/mongodb/test_cli.py
@@ -1,5 +1,13 @@
 import os
 
+import pytest
+from click.testing import CliRunner
+from pueblo.testing.dataframe import DataFrameFactory
+
+from cratedb_toolkit.cli import cli
+
+pymongo = pytest.importorskip("pymongo", reason="Skipping tests because pymongo is not installed")
+
 
 def test_version():
     """
@@ -7,3 +15,35 @@ def test_version():
     """
     exitcode = os.system("migr8 --version")  # noqa: S605,S607
     assert exitcode == 0
+
+
+def test_mongodb_load_table(caplog, cratedb, mongodb):
+    """
+    CLI test: Invoke `ctk load table` for MongoDB.
+    """
+    cratedb_url = f"{cratedb.get_connection_url()}/testdrive/demo"
+    mongodb_url = f"{mongodb.get_connection_url()}/testdrive/demo"
+
+    # Create sample dataset with a few records worth of data.
+    dff = DataFrameFactory(rows=42)
+    df = dff.make("dateindex")
+
+    # Populate source database.
+    client: pymongo.MongoClient = mongodb.get_connection_client()
+    testdrive = client.get_database("testdrive")
+    demo = testdrive.create_collection("demo")
+    demo.insert_many(df.to_dict("records"))
+
+    # Run transfer command.
+    runner = CliRunner(env={"CRATEDB_SQLALCHEMY_URL": cratedb_url})
+    result = runner.invoke(
+        cli,
+        args=f"load table {mongodb_url}",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Verify data in target database.
+    assert cratedb.database.table_exists("testdrive.demo") is True
+    assert cratedb.database.refresh_table("testdrive.demo") is True
+    assert cratedb.database.count_records("testdrive.demo") == 42

--- a/tests/io/mongodb/test_extract.py
+++ b/tests/io/mongodb/test_extract.py
@@ -3,6 +3,8 @@ import unittest
 
 import pytest
 
+pytestmark = pytest.mark.mongodb
+
 pytest.importorskip("bson", reason="Skipping tests because bson is not installed")
 pytest.importorskip("pymongo", reason="Skipping tests because pymongo is not installed")
 pytest.importorskip("rich", reason="Skipping tests because rich is not installed")

--- a/tests/io/mongodb/test_extract.py
+++ b/tests/io/mongodb/test_extract.py
@@ -1,4 +1,11 @@
+# ruff: noqa: E402
 import unittest
+
+import pytest
+
+pytest.importorskip("bson", reason="Skipping tests because bson is not installed")
+pytest.importorskip("pymongo", reason="Skipping tests because pymongo is not installed")
+pytest.importorskip("rich", reason="Skipping tests because rich is not installed")
 
 import bson
 

--- a/tests/io/mongodb/test_integration.py
+++ b/tests/io/mongodb/test_integration.py
@@ -8,6 +8,8 @@ import pytest
 
 from tests.io.mongodb.conftest import RESET_DATABASES
 
+pytestmark = pytest.mark.mongodb
+
 pymongo = pytest.importorskip("pymongo", reason="Skipping tests because pymongo is not installed")
 pytest.importorskip("rich", reason="Skipping tests because rich is not installed")
 

--- a/tests/io/mongodb/test_translate.py
+++ b/tests/io/mongodb/test_translate.py
@@ -1,6 +1,10 @@
 import unittest
 
+import pytest
+
 from cratedb_toolkit.io.mongodb import translate
+
+pytestmark = pytest.mark.mongodb
 
 
 class TestTranslate(unittest.TestCase):

--- a/tests/io/mongodb/test_util.py
+++ b/tests/io/mongodb/test_util.py
@@ -1,6 +1,10 @@
 import unittest
 
+import pytest
+
 from cratedb_toolkit.io.mongodb.util import parse_input_numbers
+
+pytestmark = pytest.mark.mongodb
 
 
 class TestInputNumberParser(unittest.TestCase):

--- a/tests/io/mongodb/test_util.py
+++ b/tests/io/mongodb/test_util.py
@@ -1,6 +1,6 @@
 import unittest
 
-from cratedb_toolkit.io.mongodb.core import parse_input_numbers
+from cratedb_toolkit.io.mongodb.util import parse_input_numbers
 
 
 class TestInputNumberParser(unittest.TestCase):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,21 @@
+from cratedb_toolkit.model import DatabaseAddress
+
+
+def test_database_address_to_httpuri_standard():
+    address = DatabaseAddress.from_string("crate://user:password@example.org/schema/table")
+    assert address.httpuri == "http://user:password@example.org/schema/table"
+
+
+def test_database_address_to_httpuri_ssl():
+    address = DatabaseAddress.from_string("crate://user:password@example.org/schema/table?ssl=true")
+    assert address.httpuri == "https://user:password@example.org/schema/table"
+
+
+def test_database_address_from_httpuri_standard():
+    address = DatabaseAddress.from_httpuri("http://user:password@example.org/schema/table")
+    assert address.dburi == "crate://user:password@example.org/schema/table"
+
+
+def test_database_address_from_httpuri_ssl():
+    address = DatabaseAddress.from_httpuri("https://user:password@example.org/schema/table")
+    assert address.dburi == "crate://user:password@example.org/schema/table?ssl=true"


### PR DESCRIPTION
## About

This patch adjusts the MongoDB adapter added with GH-76 to have the same interface like GH-77, in order to facilitate convenient data transfers from [MongoDB](https://github.com/mongodb/mongo).

## Synopsis

```shell
# Define target to be CrateDB schema=testdrive, table=demo.
export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/testdrive/demo

# Load data from database=testdrive, collection=demo.
ctk load table mongodb://localhost:27017/testdrive/demo

# Verify data has been transferred.
crash --command "SELECT * FROM testdrive.demo;"
```

## Details

The patch effectively automates the procedure outlined within the [previous README](https://github.com/crate/mongodb-cratedb-migration-tool/blob/main/README.rst) on behalf of a `mongodb_copy()` primitive.

https://github.com/crate-workbench/cratedb-toolkit/blob/c31df22b59c8019245d55b2bf10496818f3a0ecc/cratedb_toolkit/io/mongodb/api.py#L12-L70


## Reviewers Note

This PR currently can not be reviewed well, because it has multiple ancestors not merged yet. Other PRs will need to be unstacked first.
