### PR TITLE
Adapt testcontainers to be testing framework agnostic

### DIFF
--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -91,7 +91,7 @@ class CrateDBContainer(KeepaliveContainer, DbContainer):
 
         self._name = "testcontainers-cratedb"
 
-        cmd_opts = cmd_opts if cmd_opts else {}
+        cmd_opts = cmd_opts or {}
         self._command = self._build_cmd({**self.CMD_OPTS, **cmd_opts})
 
         self.CRATEDB_USER = user or self.CRATEDB_USER
@@ -110,7 +110,7 @@ class CrateDBContainer(KeepaliveContainer, DbContainer):
         for key, val in opts.items():
             if isinstance(val, bool):
                 val = str(val).lower()
-            cmd.append("-C{}={}".format(key, val))
+            cmd.append(f"-C{key}={val}")
         return " ".join(cmd)
 
     def _configure_ports(self) -> None:

--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -151,7 +151,6 @@ class CrateDBFixture:
         """
         Start testcontainer, used for tests set up
         """
-        logger.debug("Starting container % with args %", self.image, **kwargs)
         self.cratedb = CrateDBContainer(image=self.image, **kwargs)
         self.cratedb.start()
         self.database = DatabaseAdapter(dburi=self.get_connection_url())

--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -153,14 +153,14 @@ class CrateDBFixture:
     CrateDB Toolkit's `DatabaseAdapter`, agnostic of the test framework.
     """
 
-    def __init__(self, crate_version: str = "nightly"):
+    def __init__(self, crate_version: str = "nightly", **kwargs):
         self.cratedb: Optional[CrateDBContainer] = None
         self.image: str = "crate/crate:{}".format(crate_version)
         self.database: Optional[DatabaseAdapter] = None
-        self.setup()
+        self.setup(**kwargs)
 
-    def setup(self):
-        self.cratedb = CrateDBContainer(image=self.image)
+    def setup(self, **kwargs):
+        self.cratedb = CrateDBContainer(image=self.image, **kwargs)
         self.cratedb.start()
         self.database = DatabaseAdapter(dburi=self.get_connection_url())
 
@@ -168,7 +168,7 @@ class CrateDBFixture:
         if self.cratedb:
             self.cratedb.stop()
 
-    def reset(self, tables: Optional[str] = None):
+    def reset(self, tables: Optional[list] = TestDrive.RESET_TABLES):
         if tables and self.database:
             for reset_table in tables:
                 self.database.connection.exec_driver_sql(f"DROP TABLE IF EXISTS {reset_table};")

--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -98,9 +98,18 @@ class CrateDBContainer(KeepaliveContainer, DbContainer):
             cmd.append("-C{}={}".format(key, val))
         return " ".join(cmd)
 
-    def _configure(self) -> None:
+    def _configure_ports(self) -> None:
+        """
+        Bind all the ports exposed inside the container to the same port on the host
+        """
         ports = [*[self.port_to_expose], *self.extra_ports]
-        self.with_exposed_ports(*ports)
+        for port in ports:
+            # If random port is needed on the host, use host=None
+            # or invoke self.with_exposed_ports
+            self.with_bind_ports(container=port, host=port)
+
+    def _configure(self) -> None:
+        self._configure_ports()
         self.with_env("CRATEDB_USER", self.CRATEDB_USER)
         self.with_env("CRATEDB_PASSWORD", self.CRATEDB_PASSWORD)
         self.with_env("CRATEDB_DB", self.CRATEDB_DB)

--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -10,6 +10,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+# This is for Python 3.7 and 3.8 to support generic types
+# like `dict` instead of `typing.Dict
+from __future__ import annotations
+
 import logging
 import os
 from typing import Optional

--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -152,7 +152,7 @@ class CrateDBContainer(KeepaliveContainer, DbContainer):
         wait_for_logs(self, predicate="o.e.n.Node.*started", timeout=MAX_TRIES)
 
 
-class CrateDBFixture:
+class CrateDBTestAdapter:
     """
     A little helper wrapping Testcontainer's `CrateDBContainer` and
     CrateDB Toolkit's `DatabaseAdapter`, agnostic of the test framework.
@@ -194,9 +194,8 @@ class CrateDBFixture:
             return self.cratedb.get_connection_url(*args, **kwargs)
         return None
 
-    @property
-    def http_url(self):
+    def get_http_url(self, **kwargs):
         """
-        Return a URL for HTTP interface
+        Return a URL for CrateDB's HTTP endpoint
         """
-        return self.get_connection_url(dialect="http")
+        return self.get_connection_url(dialect="http", **kwargs)

--- a/doc/sandbox.md
+++ b/doc/sandbox.md
@@ -18,7 +18,7 @@ source .venv/bin/activate
 
 Install project in sandbox mode.
 ```shell
-pip install --editable='.[develop,test]'
+pip install --editable='.[io,test,develop]'
 ```
 
 Run tests. `TC_KEEPALIVE` keeps the auxiliary service containers running, which

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,8 @@ extend-ignore = [
   "RET504",
   # Unnecessary `elif` after `return` statement
   "RET505",
+  # Probable insecure usage of temporary file or directory
+  "S108",
 ]
 
 extend-exclude = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def cratedb(cratedb_service):
     """
     Provide a fresh canvas to each test case invocation, by resetting database content.
     """
-    cratedb_service.reset(tables=TestDrive.RESET_TABLES)
+    cratedb_service.reset()
     yield cratedb_service
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 import pytest
 import responses
 
-from cratedb_toolkit.testing.testcontainers.cratedb import CrateDBFixture
+from cratedb_toolkit.testing.testcontainers.cratedb import CrateDBTestAdapter
 from cratedb_toolkit.util.common import setup_logging
 
 # Use different schemas for storing the subsystem database tables, and the
@@ -43,7 +43,7 @@ def cratedb_service():
     """
     Provide a CrateDB service instance to the test suite.
     """
-    db = CrateDBFixture()
+    db = CrateDBTestAdapter()
     db.start(ports={CRATEDB_HTTP_PORT: None}, cmd_opts=CRATEDB_SETTINGS)
     db.reset(tables=RESET_TABLES)
     yield db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from cratedb_toolkit.util.common import setup_logging
 # Use different schemas for storing the subsystem database tables, and the
 # test/example data, so that they do not accidentally touch the default `doc`
 # schema.
-
 TESTDRIVE_DATA_SCHEMA = "testdrive-data"
 TESTDRIVE_EXT_SCHEMA = "testdrive-ext"
 RESET_TABLES = [
@@ -45,7 +44,7 @@ def cratedb_service():
     Provide a CrateDB service instance to the test suite.
     """
     db = CrateDBFixture()
-    db.start(port=CRATEDB_HTTP_PORT, cmd_opts=CRATEDB_SETTINGS)
+    db.start(ports={CRATEDB_HTTP_PORT: None}, cmd_opts=CRATEDB_SETTINGS)
     db.reset(tables=RESET_TABLES)
     yield db
     db.stop()

--- a/tests/testing/test_testcontainers.py
+++ b/tests/testing/test_testcontainers.py
@@ -1,0 +1,33 @@
+import pytest
+
+from cratedb_toolkit.testing.testcontainers.cratedb import CrateDBContainer
+
+
+@pytest.mark.parametrize(
+    "opts, expected",
+    [
+        pytest.param(
+            {"indices.breaker.total.limit": "90%"},
+            (
+                "-Cdiscovery.type=single-node "
+                "-Cnode.attr.storage=hot "
+                "-Cpath.repo=/tmp/snapshots "
+                "-Cindices.breaker.total.limit=90%"
+            ),
+            id="add_cmd_option",
+        ),
+        pytest.param(
+            {"discovery.type": "zen", "indices.breaker.total.limit": "90%"},
+            (
+                "-Cdiscovery.type=zen "
+                "-Cnode.attr.storage=hot "
+                "-Cpath.repo=/tmp/snapshots "
+                "-Cindices.breaker.total.limit=90%"
+            ),
+            id="override_defaults",
+        ),
+    ],
+)
+def test_build_command(opts, expected):
+    db = CrateDBContainer(cmd_opts=opts)
+    assert db._command == expected


### PR DESCRIPTION
## About

Testing: Adapt "Testcontainers" implementation to `unittest`

## References

- GH-58
- https://github.com/crate/crash/pull/408

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed

