### PR TITLE
This and that

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ release = [
   "twine<5",
 ]
 test = [
-  "pueblo[dataframe]@ git+https://github.com/pyveci/pueblo.git@develop",
+  "pueblo[dataframe]",
   "pytest<8",
   "pytest-cov<5",
   "pytest-mock<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ authors = [
   { name = "Marija Selakovic", email = "marija@crate.io" },
   { name = "Andreas Motl", email = "andreas.motl@crate.io" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
@@ -46,6 +46,7 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -85,7 +86,7 @@ dynamic = [
 dependencies = [
   "boltons<24",
   "click<9",
-  "click-aliases<2,>=1.0.3",
+  "click-aliases<2,>=1.0.4",
   "colorama<1",
   "colorlog",
   "crash",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ all = [
   "cratedb-toolkit[influxdb,io,mongodb]",
 ]
 develop = [
-  "black<24",
+  "black[jupyter]<24",
   "mypy==1.6.1",
   "poethepoet<0.25",
   "pyproject-fmt<1.4",


### PR DESCRIPTION
- Chore: Permit installation on Python 3.7
- Tests: Improve test isolation by pruning environment variables
- Chore: Use `pueblo[dataframe]` GA release
- Chore: Use `black[jupyter]` for code formatting
