### PR TITLE
SQLAlchemy Dialect: Dependencies: Use `sqlalchemy-cratedb>=0.37`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 ## Unreleased
 - Add `ctk cfr` and `ctk wtf` diagnostics programs
 - Remove support for Python 3.7
+- SQLAlchemy dialect: Use `sqlalchemy-cratedb>=0.37.0`
+  This includes the fix to the `get_table_names()` reflection method.
 
 ## 2024/06/11 v0.0.13
 - Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

--- a/cratedb_toolkit/sqlalchemy/__init__.py
+++ b/cratedb_toolkit/sqlalchemy/__init__.py
@@ -1,2 +1,1 @@
-from .patch import patch_inspector
 from .polyfill import check_uniqueness_factory, polyfill_autoincrement, polyfill_refresh_after_dml, refresh_table

--- a/cratedb_toolkit/sqlalchemy/patch.py
+++ b/cratedb_toolkit/sqlalchemy/patch.py
@@ -1,11 +1,8 @@
 import calendar
 import datetime as dt
 import json
-import typing as t
 from decimal import Decimal
 from uuid import UUID
-
-import sqlalchemy as sa
 
 try:
     import numpy as np
@@ -13,40 +10,6 @@ try:
     has_numpy = True
 except ImportError:
     has_numpy = False
-
-
-def patch_inspector():
-    """
-    When using `get_table_names()`, make sure the correct schema name gets used.
-
-    Apparently, SQLAlchemy does not honor the `search_path` of the engine, when
-    using the inspector?
-
-    FIXME: Bug in CrateDB SQLAlchemy dialect?
-    """
-
-    def get_effective_schema(engine: sa.Engine):
-        schema_name_raw = engine.url.query.get("schema")
-        schema_name = None
-        if isinstance(schema_name_raw, str):
-            schema_name = schema_name_raw
-        elif isinstance(schema_name_raw, tuple):
-            schema_name = schema_name_raw[0]
-        return schema_name
-
-    try:
-        from sqlalchemy_cratedb import dialect
-    except ImportError:  # pragma: nocover
-        from crate.client.sqlalchemy.dialect import CrateDialect as dialect
-
-    get_table_names_dist = dialect.get_table_names
-
-    def get_table_names(self, connection: sa.Connection, schema: t.Optional[str] = None, **kw: t.Any) -> t.List[str]:
-        if schema is None:
-            schema = get_effective_schema(connection.engine)
-        return get_table_names_dist(self, connection=connection, schema=schema, **kw)
-
-    dialect.get_table_names = get_table_names  # type: ignore
 
 
 def patch_encoder():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dependencies = [
   "python-dotenv<2",
   "python-slugify<9",
   "pyyaml<7",
-  "sqlalchemy-cratedb>=0.36.1,<1",
+  "sqlalchemy-cratedb>=0.37,<1",
   "sqlparse<0.6",
   "tqdm<5",
   'typing-extensions<5; python_version <= "3.7"',
@@ -140,7 +140,7 @@ full = [
 ]
 influxdb = [
   "cratedb-toolkit[io]",
-  "influxio>=0.2.1,<1",
+  "influxio>=0.3.1,<1",
 ]
 io = [
   "cr8",

--- a/tests/sqlalchemy/test_patch.py
+++ b/tests/sqlalchemy/test_patch.py
@@ -4,7 +4,6 @@ import json
 import pytest
 import sqlalchemy as sa
 
-from cratedb_toolkit.sqlalchemy import patch_inspector
 from cratedb_toolkit.sqlalchemy.patch import CrateJsonEncoderWithNumPy
 from tests.conftest import TESTDRIVE_DATA_SCHEMA
 
@@ -37,7 +36,6 @@ def test_inspector_patched(database):
     This verifies that it still works, when it properly has been assigned to
     the `?schema=` connection string URL parameter.
     """
-    patch_inspector()
     tablename = f'"{TESTDRIVE_DATA_SCHEMA}"."foobar"'
     inspector: sa.Inspector = sa.inspect(database.engine)
     database.run_sql(f"CREATE TABLE {tablename} AS SELECT 1")


### PR DESCRIPTION
## About

The new designated CrateDB SQLAlchemy dialect, `sqlalchemy-cratedb`, now includes the fix to the `get_table_names()` reflection method, which has been living as a monkeypatch variant here for a while. @surister supported us to provide test cases to the new upstream package. Thanks.


## References
- https://github.com/crate-workbench/sqlalchemy-cratedb/pull/10
- https://github.com/daq-tools/influxio/pull/128
