### PR TITLE
Packaging: Use `cloud` extra to install relevant packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
         pip install "setuptools>=64" --upgrade
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[io,test,develop]
+        pip install --use-pep517 --prefer-binary --editable=.[cloud,io,test,develop]
 
     - name: Run linter and software tests
       run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Packaging: Use `cloud` extra to install relevant packages
 
 
 ## 2024/12/18 v0.0.3

--- a/cratedb_toolkit/api/main.py
+++ b/cratedb_toolkit/api/main.py
@@ -8,7 +8,6 @@ from abc import abstractmethod
 from cratedb_toolkit.api.guide import GuidingTexts
 from cratedb_toolkit.cluster.util import get_cluster_info
 from cratedb_toolkit.exception import CroudException, OperationFailed
-from cratedb_toolkit.io.croud import CloudIo
 from cratedb_toolkit.model import ClusterInformation, DatabaseAddress, InputOutputResource, TableAddress
 
 logger = logging.getLogger(__name__)
@@ -44,6 +43,7 @@ class ManagedCluster(ClusterBase):
 
         https://console.cratedb.cloud
         """
+        from cratedb_toolkit.io.croud import CloudIo
 
         target = target or TableAddress()
 

--- a/cratedb_toolkit/cluster/util.py
+++ b/cratedb_toolkit/cluster/util.py
@@ -1,9 +1,13 @@
-from cratedb_toolkit.cluster.croud import CloudCluster
 from cratedb_toolkit.model import ClusterInformation
 
 
 def get_cluster_info(cluster_id: str) -> ClusterInformation:
     cluster_info = ClusterInformation()
-    cc = CloudCluster(cluster_id=cluster_id)
-    cluster_info.cloud = cc.get_info()
+    try:
+        from cratedb_toolkit.cluster.croud import CloudCluster
+
+        cc = CloudCluster(cluster_id=cluster_id)
+        cluster_info.cloud = cc.get_info()
+    except ImportError:
+        pass
     return cluster_info

--- a/cratedb_toolkit/job/cli.py
+++ b/cratedb_toolkit/job/cli.py
@@ -5,7 +5,10 @@ import click
 from cratedb_toolkit.job.croud import jobs_list
 from cratedb_toolkit.util.croud import get_croud_output_formats
 
-output_formats = get_croud_output_formats()
+try:
+    output_formats = get_croud_output_formats()
+except ImportError:
+    output_formats = ["UNKNOWN"]
 
 
 @click.command(name="list-jobs")

--- a/cratedb_toolkit/util/croud.py
+++ b/cratedb_toolkit/util/croud.py
@@ -9,9 +9,12 @@ import typing as t
 from unittest.mock import patch
 
 import yaml
-from croud.parser import Argument
 
 from cratedb_toolkit.exception import CroudException
+
+if t.TYPE_CHECKING:
+    from croud.parser import Argument
+
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +22,7 @@ logger = logging.getLogger(__name__)
 @dataclasses.dataclass
 class CroudCall:
     fun: t.Callable
-    specs: t.List[Argument]
+    specs: t.List["Argument"]
     arguments: t.List[str]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ dependencies = [
   "colorlog",
   "crash",
   "crate[sqlalchemy]>=0.34",
-  "croud==1.10.0",
   'importlib-metadata; python_version <= "3.7"',
   "python-dotenv<2",
   "sqlalchemy",
@@ -99,7 +98,10 @@ dependencies = [
 ]
 [project.optional-dependencies]
 all = [
-  "cratedb-toolkit[influxdb,io,mongodb]",
+  "cratedb-toolkit[cloud,influxdb,io,mongodb]",
+]
+cloud = [
+  "croud==1.10.0",
 ]
 develop = [
   "black[jupyter]<24",
@@ -271,7 +273,7 @@ format = [
   # Configure Ruff not to auto-fix (remove!):
   # unused imports (F401), unused variables (F841), `print` statements (T201), and commented-out code (ERA001).
   { cmd = "ruff --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 --ignore=ERA001 ." },
-  { cmd = "pyproject-fmt pyproject.toml" },
+  { cmd = "pyproject-fmt --keep-full-version pyproject.toml" },
 ]
 
 lint = [


### PR DESCRIPTION
## About
Don't install `croud` by default. It will not work on Python 3.7.

## References
- Problem: https://github.com/crate/crash/actions/runs/7588894584/job/20672385743?pr=408
- Unblocks: https://github.com/crate/crash/pull/408.
