### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/influxdb.yml
+++ b/.github/workflows/influxdb.yml
@@ -81,7 +81,7 @@ jobs:
         pytest -m influxdb
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
         flags: influxdb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
         poe check
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
         flags: main

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -80,7 +80,7 @@ jobs:
         pytest -m mongodb
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
         flags: mongodb


### PR DESCRIPTION
## About

`codecov-action@v4` has issues, it apparently does not upload without token any longer.

This reverts commit e4df24e8b13910d6707ae14ddfeaa9ffe0d2cf53.

## References

- https://github.com/crate-workbench/cratedb-toolkit/pull/109