### PR TITLE
Dependencies: Add `testing` extra, which installs `testcontainers` only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,16 +131,20 @@ release = [
   "twine<5",
 ]
 test = [
+  "cratedb-toolkit[testing]",
   "pueblo[dataframe]",
   "pytest<8",
   "pytest-cov<5",
   "pytest-mock<4",
   "responses<0.25",
-  "testcontainers<4",
   "testcontainers-azurite==0.0.1rc1",
   "testcontainers-minio==0.0.1rc1",
   "testcontainers-mongodb==0.0.1rc1",
 ]
+testing = [
+  "testcontainers<4",
+]
+
 [project.urls]
 changelog = "https://github.com/crate-workbench/cratedb-toolkit/blob/main/CHANGES.rst"
 documentation = "https://github.com/crate-workbench/cratedb-toolkit"


### PR DESCRIPTION
## About
The new `testing` extra is here to satisfy minimal runtime dependencies for the corresponding test layer.
