### PR TITLE
Testing: Export `cratedb_service` fixture as pytest11 entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
-.idea
-.venv*
 *.egg-info
 .eggs
-__pycache__
+.env
+.idea
 *.pyc
+.venv*
+__pycache__
 dist
 .coverage*
 coverage.xml
+/tmp

--- a/cratedb_toolkit/testing/pytest.py
+++ b/cratedb_toolkit/testing/pytest.py
@@ -1,0 +1,16 @@
+from typing import Generator
+
+import pytest
+
+from cratedb_toolkit.testing.testcontainers.cratedb import CrateDBTestAdapter
+
+
+@pytest.fixture(scope="session")
+def cratedb_service() -> Generator[CrateDBTestAdapter, None, None]:
+    """
+    Provide a CrateDB service instance to the test suite.
+    """
+    db = CrateDBTestAdapter()
+    db.start()
+    yield db
+    db.stop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,6 @@ test = [
 testing = [
   "testcontainers<4",
 ]
-
 [project.urls]
 changelog = "https://github.com/crate-workbench/cratedb-toolkit/blob/main/CHANGES.rst"
 documentation = "https://github.com/crate-workbench/cratedb-toolkit"
@@ -155,6 +154,8 @@ cratedb-retention = "cratedb_toolkit.retention.cli:cli"
 cratedb-toolkit = "cratedb_toolkit.cli:cli"
 ctk = "cratedb_toolkit.cli:cli"
 migr8 = "cratedb_toolkit.io.mongodb.cli:main"
+[project.entry-points.pytest11]
+cratedb_service = "cratedb_toolkit.testing.pytest"
 
 [tool.black]
 line-length = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def configure_database_schema(session_mocker, prune_environment):
 
 
 @pytest.fixture(scope="session")
-def cratedb_service():
+def cratedb_custom_service():
     """
     Provide a CrateDB service instance to the test suite.
     """
@@ -67,12 +67,12 @@ def cratedb_service():
 
 
 @pytest.fixture(scope="function")
-def cratedb(cratedb_service):
+def cratedb(cratedb_custom_service):
     """
     Provide a fresh canvas to each test case invocation, by resetting database content.
     """
-    cratedb_service.reset(tables=RESET_TABLES)
-    yield cratedb_service
+    cratedb_custom_service.reset(tables=RESET_TABLES)
+    yield cratedb_custom_service
 
 
 @pytest.fixture

--- a/tests/testing/test_pytest.py
+++ b/tests/testing/test_pytest.py
@@ -1,0 +1,16 @@
+import re
+
+import pytest
+
+
+@pytest.mark.skip("Does not work, because something stalls when using multiple containers")
+def test_cratedb_service(cratedb_service):
+    """
+    Verify the exported pytest fixture `cratedb_service` works as intended.
+    """
+    assert re.match(r"http://crate:@localhost:\d\d\d\d\d", cratedb_service.get_http_url())
+    assert re.match(r"crate://crate:@localhost:\d\d\d\d\d", cratedb_service.get_connection_url())
+
+    sql = "SELECT mountain FROM sys.summits ORDER BY prominence DESC LIMIT 1;"
+    highest_summit = cratedb_service.database.run_sql(sql, records=True)[0]
+    assert highest_summit["mountain"] == "Mont Blanc"


### PR DESCRIPTION
## About
Export `cratedb_service` fixture as pytest11 entrypoint.

## Details
This way, for basic needs, corresponding boilerplate code does not need to be provided by downstream projects.

When needing more configurability, you will need to define corresponding alternative fixtures, and not use the built-in provided from.
