### PR TITLE
Testing: Only optionally use the recently added `pytest11` entrypoint

### DIFF
--- a/cratedb_toolkit/testing/pytest.py
+++ b/cratedb_toolkit/testing/pytest.py
@@ -2,15 +2,26 @@ from typing import Generator
 
 import pytest
 
-from cratedb_toolkit.testing.testcontainers.cratedb import CrateDBTestAdapter
+try:
+    from cratedb_toolkit.testing.testcontainers.cratedb import CrateDBTestAdapter
 
+    @pytest.fixture(scope="session")
+    def cratedb_service() -> Generator[CrateDBTestAdapter, None, None]:
+        """
+        Provide a CrateDB service instance to the test suite.
+        """
+        db = CrateDBTestAdapter()
+        db.start()
+        yield db
+        db.stop()
 
-@pytest.fixture(scope="session")
-def cratedb_service() -> Generator[CrateDBTestAdapter, None, None]:
-    """
-    Provide a CrateDB service instance to the test suite.
-    """
-    db = CrateDBTestAdapter()
-    db.start()
-    yield db
-    db.stop()
+except ModuleNotFoundError as ex:
+    message = str(ex)
+
+    @pytest.fixture(scope="session")
+    def cratedb_service():
+        """
+        An error handling surrogate used when dependencies are not satisfied.
+        In order to use it, invoke `pip install 'cratedb-toolkit[testing]'`.
+        """
+        raise NotImplementedError(message)


### PR DESCRIPTION
## Problem
Updating to cratedb-toolkit 0.0.4 caused problems elsewhere.
- https://github.com/crate/cratedb-examples/pull/289

## Details
Corresponding functionality depends on `testcontainers`, which is not always installed. It is only available out of the box when installing Toolkit using `pip install 'cratedb-toolkit[testing]'`.

## Solution
This patch compensates for that, by catching corresponding `ModuleNotFoundError`s, to not make the package bail out when used without `testing`.
