### PR TITLE
Add `cratedb_toolkit.datasets` subsystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+- Added `cratedb_toolkit.datasets` subsystem
+
 
 ## 2024/02/12 v0.0.5
 

--- a/cratedb_toolkit/datasets/README.md
+++ b/cratedb_toolkit/datasets/README.md
@@ -1,0 +1,12 @@
+# CrateDB Datasets API
+
+Provide access to datasets, to be easily consumed by tutorials
+and/or production applications.
+
+## Synopsis
+```python
+from cratedb_toolkit.datasets import load_dataset
+
+dataset = load_dataset("tutorial/weather-basic")
+dataset.to_cratedb(dburi="crate://crate@localhost/", table="weather_data")
+```

--- a/cratedb_toolkit/datasets/__init__.py
+++ b/cratedb_toolkit/datasets/__init__.py
@@ -1,0 +1,1 @@
+from .core import load_dataset  # noqa: F401

--- a/cratedb_toolkit/datasets/core.py
+++ b/cratedb_toolkit/datasets/core.py
@@ -1,0 +1,8 @@
+import cratedb_toolkit.datasets.tutorial  # noqa: F401
+
+from .model import Dataset
+from .store import registry
+
+
+def load_dataset(name: str) -> Dataset:
+    return registry.find(name)

--- a/cratedb_toolkit/datasets/model.py
+++ b/cratedb_toolkit/datasets/model.py
@@ -1,0 +1,67 @@
+import dataclasses
+import typing as t
+
+import requests
+import sqlparse
+
+from cratedb_toolkit.util import DatabaseAdapter
+
+
+@dataclasses.dataclass
+class Dataset:
+    """
+    Wrapper around a dataset.
+    """
+
+    name: str
+    data_url: str
+    load_url: str
+
+    # Native datasets wrapper handle, e.g. `datasets`
+    # https://github.com/huggingface/datasets
+    handle: t.Optional[t.Any] = None
+
+    def to_cratedb(
+        self,
+        dburi: str,
+        table: str,
+        if_exists: t.Literal["append", "noop", "replace"] = "noop",
+        drop: bool = False,
+    ):
+        """
+        Load dataset into CrateDB, using SQL.
+        """
+        sql = requests.get(self.load_url, timeout=5).text
+        sql = sql.format(table=table)
+        db = DatabaseAdapter(dburi=dburi)
+
+        if drop:
+            db.drop_table(table)
+
+        if if_exists == "replace":
+            db.prune_table(table, errors="ignore")
+
+        cardinality = db.count_records(table, errors="ignore")
+        has_data = cardinality > 0
+
+        if not has_data and not if_exists == "noop":
+            for statement in sqlparse.parse(sql):
+                db.run_sql(str(statement))
+
+
+class DatasetRegistry:
+    """
+    Manage multiple datasets, and provide discovery.
+    """
+
+    def __init__(self):
+        self.datasets: t.List[Dataset] = []
+
+    def add(self, dataset: Dataset):
+        self.datasets.append(dataset)
+
+    def find(self, name: str) -> Dataset:
+        for dataset in self.datasets:
+            if dataset.name == name:
+                return dataset
+        raise KeyError(f"Dataset not found: {name}")

--- a/cratedb_toolkit/datasets/store.py
+++ b/cratedb_toolkit/datasets/store.py
@@ -1,0 +1,3 @@
+from cratedb_toolkit.datasets.model import DatasetRegistry
+
+registry = DatasetRegistry()

--- a/cratedb_toolkit/datasets/tutorial.py
+++ b/cratedb_toolkit/datasets/tutorial.py
@@ -1,0 +1,38 @@
+from cratedb_toolkit.datasets.model import Dataset
+from cratedb_toolkit.datasets.store import registry
+
+devices_info = Dataset(
+    name="tutorial/devices-info",
+    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/devices_info.json.gz",
+    load_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_devices_info.sql",
+)
+
+devices_readings = Dataset(
+    name="tutorial/devices-readings",
+    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/devices_readings.json.gz",
+    load_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_devices_readings.sql",
+)
+
+marketing = Dataset(
+    name="tutorial/marketing",
+    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_marketing.json.gz",
+    load_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_marketing.sql",
+)
+
+netflix = Dataset(
+    name="tutorial/netflix",
+    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_netflix.json.gz",
+    load_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_netflix.sql",
+)
+
+weather = Dataset(
+    name="tutorial/weather-basic",
+    data_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_weather.csv.gz",
+    load_url="https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/load_weather.sql",
+)
+
+registry.add(devices_info)
+registry.add(devices_readings)
+registry.add(marketing)
+registry.add(netflix)
+registry.add(weather)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ test = [
   "testcontainers-mongodb==0.0.1rc1",
 ]
 testing = [
+  "python-slugify<9",
   "testcontainers<4",
 ]
 [project.urls]

--- a/tests/datasets/conftest.py
+++ b/tests/datasets/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from cratedb_toolkit.util import DatabaseAdapter
+from tests.conftest import TESTDRIVE_DATA_SCHEMA
+
+
+@pytest.fixture
+def database(cratedb):
+    """
+    Provide a client database adapter, which is connected to the test database instance.
+    """
+    database_url = cratedb.get_connection_url() + "?schema=" + TESTDRIVE_DATA_SCHEMA
+    yield DatabaseAdapter(dburi=database_url)

--- a/tests/datasets/test_tutorials.py
+++ b/tests/datasets/test_tutorials.py
@@ -1,0 +1,38 @@
+import pytest
+from slugify import slugify
+
+from cratedb_toolkit.datasets import load_dataset
+from cratedb_toolkit.datasets.model import Dataset
+from cratedb_toolkit.datasets.store import registry
+from cratedb_toolkit.util import DatabaseAdapter
+
+datasets = registry.datasets
+dataset_names = [dataset.name for dataset in datasets]
+
+
+@pytest.mark.parametrize("dataset", datasets, ids=dataset_names)
+def test_dataset_replace(database: DatabaseAdapter, dataset: Dataset):
+    """
+    Verify loading dataset into CrateDB table, with "if_exists=replace" option.
+    """
+    dataset = load_dataset(dataset.name)
+    tablename = slugify(dataset.name, separator="_")
+    dataset.to_cratedb(dburi=database.dburi, table=tablename, if_exists="replace")
+
+
+def test_dataset_noop(database: DatabaseAdapter):
+    """
+    Verify loading dataset into CrateDB table, with "if_exists=noop" option.
+    """
+    dataset = load_dataset("tutorial/weather-basic")
+    tablename = slugify(dataset.name, separator="_")
+    dataset.to_cratedb(dburi=database.dburi, table=tablename, if_exists="noop")
+
+
+def test_dataset_drop(database: DatabaseAdapter):
+    """
+    Verify loading dataset into CrateDB table, with "drop table" option.
+    """
+    dataset = load_dataset("tutorial/weather-basic")
+    tablename = slugify(dataset.name, separator="_")
+    dataset.to_cratedb(dburi=database.dburi, table=tablename, drop=True)

--- a/tests/sqlalchemy/test_patch.py
+++ b/tests/sqlalchemy/test_patch.py
@@ -15,7 +15,7 @@ def test_inspector_vanilla(database):
     assert inspector.has_schema(TESTDRIVE_DATA_SCHEMA) is True
 
     table_names = inspector.get_table_names(schema=TESTDRIVE_DATA_SCHEMA)
-    assert table_names == ["foobar"]
+    assert "foobar" in table_names
 
     view_names = inspector.get_view_names(schema=TESTDRIVE_DATA_SCHEMA)
     assert view_names == []
@@ -39,4 +39,4 @@ def test_inspector_patched(database):
     assert inspector.has_schema(TESTDRIVE_DATA_SCHEMA) is True
 
     table_names = inspector.get_table_names()
-    assert table_names == ["foobar"]
+    assert "foobar" in table_names


### PR DESCRIPTION
## About
Provide access to datasets, to be easily consumed by tutorials
and/or production applications.

## Synopsis
```python
from cratedb_toolkit.datasets import load_dataset

dataset = load_dataset("tutorial/weather-basic")
dataset.to_cratedb(dburi="crate://crate@localhost/", table="weather_data")
```

## References
- https://github.com/crate-workbench/cratedb-toolkit/issues/89
- https://github.com/crate/cratedb-datasets/pull/9
