### PR TITLE
Dependencies: Use `dask[dataframe]`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Dependencies: Use `dask[dataframe]`
 
 ## 2024/03/11 v0.0.8
 - datasets: Fix compatibility with Python 3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ influxdb = [
 ]
 io = [
   "cr8",
-  "dask>=2020,<=2024.2.1",
+  "dask[dataframe]>=2020,<=2024.2.1",
   "pandas<3,>=1",
 ]
 mongodb = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ develop = [
   "validate-pyproject<0.17",
 ]
 influxdb = [
-  "influxio==0.1.1",
+  "influxio==0.1.2",
 ]
 io = [
   "cr8",


### PR DESCRIPTION
## Problem

```python
>           import dask_expr  # noqa: F401
E           ModuleNotFoundError: No module named 'dask_expr'
```

-- https://github.com/crate-workbench/cratedb-toolkit/actions/runs/8258902237/job/22591947853#step:5:43

## References
- https://github.com/daq-tools/influxio/pull/85
- https://github.com/microsoft/LightGBM/issues/6365
- https://github.com/microsoft/LightGBM/pull/6357
