### PR TITLE
Dependencies: Unpin upper version bound of `dask`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 
 ## Unreleased
+- Dependencies: Unpin upper version bound of `dask`. Otherwise, compatibility
+  issues can not be resolved quickly, like with Python 3.11.9.
+  https://github.com/dask/dask/issues/11038
 
 ## 2024/03/22 v0.0.9
 - Dependencies: Use `dask[dataframe]`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ influxdb = [
 ]
 io = [
   "cr8",
-  "dask[dataframe]>=2020,<=2024.2.1",
+  "dask[dataframe]>=2020",
   "pandas<3,>=1",
 ]
 mongodb = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ develop = [
   "validate-pyproject<0.17",
 ]
 influxdb = [
-  "influxio==0.1.2",
+  "influxio==0.2.0",
 ]
 io = [
   "cr8",

--- a/tests/io/influxdb/test_cli.py
+++ b/tests/io/influxdb/test_cli.py
@@ -12,7 +12,7 @@ pytest.importorskip(
     "influxdb_client", reason="Skipping InfluxDB tests because 'influxdb-client' package is not installed"
 )
 
-from influxio.model import InfluxDbAdapter
+from influxio.adapter import InfluxDbApiAdapter
 
 
 def test_influxdb2_load_table(caplog, cratedb, influxdb):
@@ -27,7 +27,7 @@ def test_influxdb2_load_table(caplog, cratedb, influxdb):
     df = dff.make("dateindex")
 
     # Populate source database.
-    adapter = InfluxDbAdapter.from_url(influxdb_url)
+    adapter = InfluxDbApiAdapter.from_url(influxdb_url)
     adapter.ensure_bucket()
     adapter.write_df(df)
 


### PR DESCRIPTION
## Details

Otherwise, compatibility issues can not be resolved quickly, like with Python 3.11.9.

## References
- https://github.com/dask/dask/issues/11038
- https://github.com/pycaret/pycaret/issues/3960#issuecomment-2045881422
