### PR TITLE
Fix InfluxDB Cloud <-> CrateDB Cloud connectivity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Dependencies: Update to `influxio<1`
 
 ## 2024/04/10 v0.0.10
 - Dependencies: Unpin upper version bound of `dask`. Otherwise, compatibility

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 
 ## Unreleased
-- Dependencies: Update to `influxio<1`
+- Fix InfluxDB Cloud <-> CrateDB Cloud connectivity by propagating
+  `ssl=true` query argument. Update dependencies to `influxio>=0.2.1,<1`.
 
 ## 2024/04/10 v0.0.10
 - Dependencies: Unpin upper version bound of `dask`. Otherwise, compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ docs = [
 ]
 influxdb = [
   "cratedb-toolkit[io]",
-  "influxio==0.2.0",
+  "influxio<1",
 ]
 io = [
   "cr8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ docs = [
 ]
 influxdb = [
   "cratedb-toolkit[io]",
-  "influxio<1",
+  "influxio>=0.2.1,<1",
 ]
 io = [
   "cr8",


### PR DESCRIPTION
## About
Use more recent influxio package, which resolves a problem when connecting to CrateDB Cloud, by propagating `ssl=true` query argument.

## What's Inside
Update dependencies to `influxio>=0.2.1,<1`.

## References
- https://github.com/daq-tools/influxio/issues/125