### PR TITLE
cfr: Add support to directly export to an archive file

### DIFF
--- a/tests/cfr/test_cli.py
+++ b/tests/cfr/test_cli.py
@@ -1,7 +1,9 @@
 import json
+import os.path
 import re
 import shutil
 import sys
+import tarfile
 
 import tests
 
@@ -44,6 +46,44 @@ def test_cfr_cli_export_success(cratedb, tmp_path, caplog):
 
     schema_files = filenames(path / "schema")
     data_files = filenames(path / "data")
+
+    assert len(schema_files) >= 19
+    assert len(data_files) >= 10
+
+
+def test_cfr_cli_export_to_archive_file(cratedb, tmp_path, caplog):
+    """
+    Verify `ctk cfr sys-export some-file.tgz` works.
+    """
+
+    target = os.path.join(tmp_path, "cluster-data.tgz")
+
+    # Invoke command.
+    runner = CliRunner(env={"CRATEDB_SQLALCHEMY_URL": cratedb.database.dburi, "CFR_TARGET": str(tmp_path)})
+    result = runner.invoke(
+        cli,
+        args=f"--debug sys-export {target}",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Verify log output.
+    assert "Exporting system tables to" in caplog.text
+    assert re.search(r"Successfully exported \d+ system tables", caplog.text), "Log message missing"
+
+    # Verify outcome.
+    path = Path(json.loads(result.output)["path"])
+    assert "cluster-data.tgz" in path.name
+
+    data_files = []
+    schema_files = []
+    with tarfile.open(path, "r") as tar:
+        name_list = tar.getnames()
+        for name in name_list:
+            if "data" in name:
+                data_files.append(name)
+            elif "schema" in name:
+                schema_files.append(name)
 
     assert len(schema_files) >= 19
     assert len(data_files) >= 10


### PR DESCRIPTION
Some CFR improvements:
 - Add support to directly export the system tables into a `tgz` file