### PR TITLE
Fix InfluxDB Cloud <-> CrateDB Cloud connectivity once more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 
 ## Unreleased
+- Fix InfluxDB Cloud <-> CrateDB Cloud connectivity by using
+  `ssl=true` query argument also for `influxdb2://` source URLs.
 
 ## 2024/05/30 v0.0.11
 - Fix InfluxDB Cloud <-> CrateDB Cloud connectivity by propagating

--- a/cratedb_toolkit/api/main.py
+++ b/cratedb_toolkit/api/main.py
@@ -5,10 +5,13 @@ import logging
 import typing as t
 from abc import abstractmethod
 
+from yarl import URL
+
 from cratedb_toolkit.api.guide import GuidingTexts
 from cratedb_toolkit.cluster.util import get_cluster_info
 from cratedb_toolkit.exception import CroudException, OperationFailed
 from cratedb_toolkit.model import ClusterInformation, DatabaseAddress, InputOutputResource, TableAddress
+from cratedb_toolkit.util.data import asbool
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +112,11 @@ class StandaloneCluster(ClusterBase):
         if source_url.startswith("influxdb"):
             from cratedb_toolkit.io.influxdb import influxdb_copy
 
-            source_url = source_url.replace("influxdb2://", "http://")
+            http_scheme = "http://"
+            source_url_obj = URL(source_url)
+            if asbool(source_url_obj.query.get("ssl")):
+                http_scheme = "https://"
+            source_url = source_url.replace("influxdb2://", http_scheme)
             if not influxdb_copy(source_url, target_url, progress=True):
                 msg = "Data loading failed"
                 logger.error(msg)

--- a/cratedb_toolkit/testing/testcontainers/util.py
+++ b/cratedb_toolkit/testing/testcontainers/util.py
@@ -12,25 +12,12 @@
 #    under the License.
 import logging
 import os
-from typing import Any
 
 from testcontainers.core.container import DockerContainer
 
+from cratedb_toolkit.util.data import asbool
+
 logger = logging.getLogger(__name__)
-
-
-# from sqlalchemy.util.langhelpers
-# from paste.deploy.converters
-def asbool(obj: Any) -> bool:
-    if isinstance(obj, str):
-        obj = obj.strip().lower()
-        if obj in ["true", "yes", "on", "y", "t", "1"]:
-            return True
-        elif obj in ["false", "no", "off", "n", "f", "0"]:
-            return False
-        else:
-            raise ValueError("String is not true/false: %r" % obj)
-    return bool(obj)
 
 
 class ExtendedDockerContainer(DockerContainer):

--- a/cratedb_toolkit/util/data.py
+++ b/cratedb_toolkit/util/data.py
@@ -16,3 +16,17 @@ def str_contains(haystack, *needles):
     """
     haystack = str(haystack)
     return any(needle in haystack for needle in needles)
+
+
+# from sqlalchemy.util.langhelpers
+# from paste.deploy.converters
+def asbool(obj: t.Any) -> bool:
+    if isinstance(obj, str):
+        obj = obj.strip().lower()
+        if obj in ["true", "yes", "on", "y", "t", "1"]:
+            return True
+        elif obj in ["false", "no", "off", "n", "f", "0"]:
+            return False
+        else:
+            raise ValueError("String is not true/false: %r" % obj)
+    return bool(obj)

--- a/doc/io/influxdb/loader.md
+++ b/doc/io/influxdb/loader.md
@@ -16,9 +16,14 @@ working with InfluxDB.
 pip install --upgrade 'cratedb-toolkit[influxdb]'
 ```
 
-## Example
-Import two data points into InfluxDB.
+## Examples
 
+### Workstation
+
+An exemplary walkthrough, copying data from InfluxDB to CrateDB, both services
+expected to be listening on `localhost`.
+
+Import two data points into InfluxDB.
 ```shell
 export INFLUX_ORG=example
 export INFLUX_TOKEN=token
@@ -47,6 +52,19 @@ ctk show table "testdrive.demo"
 :::{todo}
 - More convenient table querying.
 :::
+
+
+### Cloud
+
+A canonical invocation for copying data from InfluxDB Cloud to CrateDB Cloud.
+Please note the `ssl=true` query parameter at the end of both database
+connection URLs.
+
+```shell
+ctk load table \
+  "influxdb2://9fafc869a91a3517:T268DVLDHD8...oPic4A==@eu-central-1-1.aws.cloud2.influxdata.com/testdrive/demo?ssl=true" \
+  --cratedb-sqlalchemy-url="crate://admin:dZ...6LqB@green-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200/testdrive/demo?ssl=true"
+```
 
 
 [influxio]: inv:influxio:*:label#index


### PR DESCRIPTION
... by using `ssl=true` query argument also for `influxdb2://` source URLs.

## Documentation
A preview: https://cratedb-toolkit--154.org.readthedocs.build/io/influxdb/loader.html#cloud

## References
- A follow-up to GH-152