### PR TITLE
CI: Run nightly testing jobs each second night only

### DIFF
--- a/.github/workflows/influxdb.yml
+++ b/.github/workflows/influxdb.yml
@@ -18,9 +18,11 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
-  # Run job each night after CrateDB nightly has been published.
+  # Run job each second night after CrateDB nightly has been published.
+  # The reason about "why each second night", is because free capacity
+  # for Codecov uploads is limited.
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 */2 * *'
 
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
@@ -89,4 +91,4 @@ jobs:
         flags: influxdb
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,11 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
-  # Run job each night after CrateDB nightly has been published.
+  # Run job each second night after CrateDB nightly has been published.
+  # The reason about "why each second night", is because free capacity
+  # for Codecov uploads is limited.
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 */2 * *'
 
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
@@ -83,4 +85,4 @@ jobs:
         flags: main
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -18,9 +18,11 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
-  # Run job each night after CrateDB nightly has been published.
+  # Run job each second night after CrateDB nightly has been published.
+  # The reason about "why each second night", is because free capacity
+  # for Codecov uploads is limited.
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 */2 * *'
 
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
@@ -88,4 +90,4 @@ jobs:
         flags: mongodb
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true


### PR DESCRIPTION
The reason is because free capacity for Codecov uploads is limited, currently starting to trip on the 20th of each month, due to nightly usage. This patch follows up on 2554a50c9a, by steering the workaround for this edge case into a different direction.