### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`
 
 ## 2024/05/30 v0.0.12
 - Fix InfluxDB Cloud <-> CrateDB Cloud connectivity by using

--- a/cratedb_toolkit/sqlalchemy/patch.py
+++ b/cratedb_toolkit/sqlalchemy/patch.py
@@ -22,13 +22,16 @@ def patch_inspector():
             schema_name = schema_name_raw[0]
         return schema_name
 
-    from crate.client.sqlalchemy.dialect import CrateDialect
+    try:
+        from sqlalchemy_cratedb import dialect
+    except ImportError:  # pragma: nocover
+        from crate.client.sqlalchemy.dialect import CrateDialect as dialect
 
-    get_table_names_dist = CrateDialect.get_table_names
+    get_table_names_dist = dialect.get_table_names
 
     def get_table_names(self, connection: sa.Connection, schema: t.Optional[str] = None, **kw: t.Any) -> t.List[str]:
         if schema is None:
             schema = get_effective_schema(connection.engine)
         return get_table_names_dist(self, connection=connection, schema=schema, **kw)
 
-    CrateDialect.get_table_names = get_table_names  # type: ignore
+    dialect.get_table_names = get_table_names  # type: ignore

--- a/cratedb_toolkit/testing/pytest.py
+++ b/cratedb_toolkit/testing/pytest.py
@@ -10,7 +10,7 @@ try:
         """
         Provide a CrateDB service instance to the test suite.
         """
-        db = CrateDBTestAdapter()
+        db = CrateDBTestAdapter(crate_version="nightly")
         db.start()
         yield db
         db.stop()

--- a/cratedb_toolkit/util/common.py
+++ b/cratedb_toolkit/util/common.py
@@ -20,6 +20,7 @@ def setup_logging(level=logging.INFO, verbose: bool = False):
         logging.getLogger("sqlalchemy").setLevel(level)
 
     logging.getLogger("crate.client").setLevel(level)
+    logging.getLogger("sqlalchemy_cratedb").setLevel(level)
     logging.getLogger("urllib3.connectionpool").setLevel(level)
 
     # logging.getLogger("docker.auth").setLevel(logging.INFO)  # noqa: ERA001

--- a/cratedb_toolkit/util/database.py
+++ b/cratedb_toolkit/util/database.py
@@ -244,7 +244,11 @@ class DatabaseAdapter:
         Import CSV data using pandas.
         """
         import pandas as pd
-        from crate.client.sqlalchemy.support import insert_bulk
+
+        try:
+            from sqlalchemy_cratedb.support import insert_bulk
+        except ImportError:  # pragma: nocover
+            from crate.client.sqlalchemy.support import insert_bulk
 
         df = pd.read_csv(filepath)
         with self.engine.connect() as connection:
@@ -267,7 +271,11 @@ class DatabaseAdapter:
         """
         import dask.dataframe as dd
         import pandas as pd
-        from crate.client.sqlalchemy.support import insert_bulk
+
+        try:
+            from sqlalchemy_cratedb.support import insert_bulk
+        except ImportError:  # pragma: nocover
+            from crate.client.sqlalchemy.support import insert_bulk
 
         # Set a few defaults.
         npartitions = npartitions or os.cpu_count()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,11 @@ dependencies = [
   "colorama<1",
   "colorlog",
   "crash",
-  "crate[sqlalchemy]>=0.34",
+  "crate==1.0.0dev0",
   'importlib-metadata; python_version <= "3.7"',
   "python-dotenv<2",
   "python-slugify<9",
-  "sqlalchemy",
+  "sqlalchemy-cratedb",
   "sqlparse<0.6",
   'typing-extensions<5; python_version <= "3.7"',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def cratedb_custom_service():
     """
     Provide a CrateDB service instance to the test suite.
     """
-    db = CrateDBTestAdapter()
+    db = CrateDBTestAdapter(crate_version="nightly")
     db.start(ports={CRATEDB_HTTP_PORT: None}, cmd_opts=CRATEDB_SETTINGS)
     db.reset(tables=RESET_TABLES)
     yield db


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch verifies and concludes the migration.

## References
- https://github.com/crate/roadmap/issues/85
