### PR TITLE
Use sqlalchemy's 'quote' function to quote table names and fix table quoting in cfr exporter

### DIFF
--- a/cratedb_toolkit/cfr/systable.py
+++ b/cratedb_toolkit/cfr/systable.py
@@ -166,7 +166,7 @@ class SystemTableExporter(PathProvider):
 
             path_table_schema = path_schema / f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}.sql"
             path_table_data = path_data / f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}.{self.data_format}"
-            tablename_out = f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}"
+            tablename_out = self.adapter.quote_relation_name(f"{ExportSettings.TABLE_FILENAME_PREFIX}{tablename}")
 
             # Write schema file.
             with open(path_table_schema, "w") as fh_schema:

--- a/cratedb_toolkit/testing/testcontainers/cratedb.py
+++ b/cratedb_toolkit/testing/testcontainers/cratedb.py
@@ -24,7 +24,6 @@ from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_
 
 from cratedb_toolkit.testing.testcontainers.util import KeepaliveContainer, asbool
 from cratedb_toolkit.util import DatabaseAdapter
-from cratedb_toolkit.util.database import quote_table_name
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +188,9 @@ class CrateDBTestAdapter:
         """
         if tables and self.database:
             for reset_table in tables:
-                self.database.connection.exec_driver_sql(f"DROP TABLE IF EXISTS {quote_table_name(reset_table)};")
+                self.database.connection.exec_driver_sql(
+                    f"DROP TABLE IF EXISTS {self.database.quote_relation_name(reset_table)};"
+                )
 
     def get_connection_url(self, *args, **kwargs):
         """

--- a/tests/cfr/test_cli.py
+++ b/tests/cfr/test_cli.py
@@ -108,6 +108,22 @@ def test_cfr_cli_export_failure(cratedb, tmp_path, caplog):
     assert result.output == ""
 
 
+def test_cfr_cli_export_ensure_table_name_is_quoted(cratedb, tmp_path, caplog):
+    runner = CliRunner(env={"CRATEDB_SQLALCHEMY_URL": cratedb.database.dburi, "CFR_TARGET": str(tmp_path)})
+    result = runner.invoke(
+        cli,
+        args="--debug sys-export",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    path = Path(json.loads(result.output)["path"])
+    sys_cluster_table_schema = path / "schema" / "sys-cluster.sql"
+    with open(sys_cluster_table_schema, "r") as f:
+        content = f.read()
+        assert '"sys-cluster"' in content, "Table name missing or not quoted"
+
+
 def test_cfr_cli_import_success(cratedb, tmp_path, caplog):
     """
     Verify `ctk cfr sys-import` works.

--- a/tests/util/database.py
+++ b/tests/util/database.py
@@ -1,0 +1,23 @@
+import pytest
+
+from cratedb_toolkit.util import DatabaseAdapter
+
+
+def test_quote_relation_name():
+    database = DatabaseAdapter(dburi="crate://localhost")
+    assert database.quote_relation_name("my_table") == "my_table"
+    assert database.quote_relation_name("my-table") == '"my-table"'
+    assert database.quote_relation_name("MyTable") == '"MyTable"'
+    assert database.quote_relation_name('"MyTable"') == '"MyTable"'
+    assert database.quote_relation_name("my_schema.my_table") == "my_schema.my_table"
+    assert database.quote_relation_name("my-schema.my_table") == '"my-schema".my_table'
+    assert database.quote_relation_name('"wrong-quoted-fqn.my_table"') == '"wrong-quoted-fqn.my_table"'
+    assert database.quote_relation_name('"my_schema"."my_table"') == '"my_schema"."my_table"'
+    # reserved keyword must be quoted
+    assert database.quote_relation_name("table") == '"table"'
+
+
+def test_quote_relation_name_with_invalid_fqn():
+    database = DatabaseAdapter(dburi="crate://localhost")
+    with pytest.raises(ValueError):
+        database.quote_relation_name("my-db.my-schema.my-table")


### PR DESCRIPTION
See commits.

Closes #168.