### PR TITLE
CI: Add GHA workflow recipe for staging packages to PyPI, `release-pypi.yml`

### DIFF
--- a/.github/workflows/release-oci.yml
+++ b/.github/workflows/release-oci.yml
@@ -1,5 +1,5 @@
 # Stage OCI container images through GitHub Actions (GHA) to GitHub Container Registry (GHCR).
-name: OCI
+name: Release OCI to GHCR
 
 on:
   pull_request: ~

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,35 @@
+# Stage Python source distribution and wheel packages through GitHub Actions (GHA) to Python Package Index (PyPI).
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  build-and-publish:
+    name: Build & publish package to PyPI
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+
+      - name: Build package
+        run: |
+          python -m pip install build twine
+          python -m build
+          twine check dist/{*.tar.gz,*.whl}
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/doc/index.md
+++ b/doc/index.md
@@ -34,9 +34,10 @@ Ad Hoc Diagnosis (WTF) <wtf/index>
 :caption: Workbench
 :hidden:
 
-sandbox
 changes
 backlog
+sandbox
+release
 ```
 
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,0 +1,40 @@
+# Releasing
+
+
+## About
+
+When running the release procedure, several GitHub Action workflows will be
+triggered, building and publishing different kinds of artefacts.
+
+- Python source distribution and wheel packages, published to the Python Package Index (PyPI).
+
+  https://pypi.org/project/cratedb-toolkit/
+
+- OCI container images, published to the GitHub Container Registry (GHCR).
+
+  https://github.com/crate-workbench/cratedb-toolkit/pkgs/container/cratedb-toolkit
+
+The signal to start the release pipeline is by tagging the Git repository,
+and pushing that tag to remote.
+
+
+## Procedure
+
+On branch `main`:
+
+- Add a section for the new version in the `CHANGES.md` file.
+- Commit your changes with a message like `Release x.y.z`.
+- Create a tag, and push to remote.
+  This will trigger a GitHub action which releases the new version to PyPi.
+  ```shell
+  git tag v0.0.14
+  git git push && push --tags
+  ```
+- On GitHub, designate a new release, copying in the relevant section
+  from the CHANGELOG.
+  https://github.com/crate-workbench/cratedb-toolkit/releases
+
+Optionally, build the package and upload to PyPI manually.
+```shell
+poe release
+```


### PR DESCRIPTION
## About
Automate the PyPI release procedure by staging packages through GHA.

## Details
- The GHA recipe is derived from `sqlalchemy-cratedb`'s [release.yml](https://github.com/crate-workbench/sqlalchemy-cratedb/blob/main/.github/workflows/release.yml).
- The `PYPI_API_TOKEN` variable has been added to the [secrets section](https://github.com/crate-workbench/cratedb-toolkit/settings/secrets/actions) of this repository.
