### PR TITLE
Add support to publish cfr as a binary using PyInstaller

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,0 +1,75 @@
+# Stage PyInstaller application bundles through GitHub Actions (GHA) to GitHub Workflow Artifacts.
+# https://github.com/actions/upload-artifact#where-does-the-upload-go
+
+name: "Release: Application Bundle"
+
+on:
+  pull_request: ~
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  cfr:
+    name: "CFR for OS ${{ matrix.os }}"
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [
+          "macos-13",        # Intel
+          "macos-latest",    # ARM
+          "ubuntu-latest",   # Intel
+          "windows-latest",  # Intel
+        ]
+      # TODO: Also build for Linux/ARM, because this platform gets more traction in datacenters.
+      # - https://github.blog/changelog/2024-06-03-actions-arm-based-linux-and-windows-runners-are-now-in-public-beta/
+      # - https://arm-software.github.io/AVH/main/infrastructure/html/avh_gh.html
+      # - via: https://github.com/actions/partner-runner-images
+
+    steps:
+
+    - name: Acquire sources
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: 'pyproject.toml'
+
+    - name: Set up project
+      run: pip install --use-pep517 --prefer-binary --editable='.[cfr,release-cfr]'
+
+    - name: Build application bundle
+      run: poe build-cfr
+
+    - name: Compute artifact suffix (OS-ARCH)
+      id: artifact-suffix
+      uses: ASzc/change-string-case-action@v6
+      with:
+        string: "${{ runner.os }}-${{ runner.arch }}"
+
+    - name: Upload artifact to Workflow Artifacts (Linux and macOS)
+      if: runner.os != 'Windows'
+      uses: actions/upload-artifact@v4
+      with:
+        name: "cratedb-cfr-${{ steps.artifact-suffix.outputs.lowercase }}"
+        path: dist/cratedb-cfr
+
+    - name: Upload artifact to Workflow Artifacts (Windows)
+      if: runner.os == 'Windows'
+      uses: actions/upload-artifact@v4
+      with:
+        name: "cratedb-cfr-${{ steps.artifact-suffix.outputs.lowercase }}"
+        path: dist/cratedb-cfr.exe
+
+    - name: Upload artifact to release assets
+      if: startsWith(github.event.ref, 'refs/tags')
+      run: echo "Not implemented yet."
+      # TODO: Upload to release assets, when invoked on "tag" event.
+      # https://github.com/grafana-toolbox/grafana-client/blob/4.1.0/.github/workflows/release.yml#L27-L42
+      # https://github.com/marketplace/actions/create-release

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - SQLAlchemy: Clean up and refactor SQLAlchemy polyfills
   to `cratedb_toolkit.util.sqlalchemy`
 - CFR: Build as a self-contained program using PyInstaller
+- CFR: Publish self-contained application bundle to GitHub Workflow Artifacts
 
 ## 2024/06/18 v0.0.14
 - Add `ctk cfr` and `ctk wtf` diagnostics programs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - MongoDB: Added adapter amalgamating PyMongo to use CrateDB as backend
 - SQLAlchemy: Clean up and refactor SQLAlchemy polyfills
   to `cratedb_toolkit.util.sqlalchemy`
+- CFR: Build as a self-contained program using PyInstaller
 
 ## 2024/06/18 v0.0.14
 - Add `ctk cfr` and `ctk wtf` diagnostics programs

--- a/cratedb_toolkit/cfr/cli.py
+++ b/cratedb_toolkit/cfr/cli.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021-2024, Crate.io Inc.
 # Distributed under the terms of the AGPLv3 license, see LICENSE.
 import logging
+import multiprocessing
 import sys
 
 import click
@@ -77,3 +78,10 @@ def sys_import(ctx: click.Context, source: str):
     except Exception as ex:
         error_logger(ctx)(ex)
         sys.exit(1)
+
+
+if getattr(sys, "frozen", False):
+    # https://github.com/pyinstaller/pyinstaller/issues/6368
+    multiprocessing.freeze_support()
+    # https://stackoverflow.com/questions/45090083/freeze-a-program-created-with-pythons-click-pacage
+    cli(sys.argv[1:])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,8 @@ all = [
   "cratedb-toolkit[full,influxdb,mongodb]",
 ]
 cfr = [
-  "pandas<3,>=1",
-  "pyarrow<17",
+  "pandas<2.2",
+  "pyarrow<16.1",
 ]
 cloud = [
   "croud==1.11.1",
@@ -167,6 +167,9 @@ release = [
   "build<2",
   "twine<6",
 ]
+release-cfr = [
+  "pyinstaller<7",
+]
 service = [
   "fastapi<0.112",
   "uvicorn<0.31",
@@ -195,6 +198,7 @@ documentation = "https://github.com/crate-workbench/cratedb-toolkit"
 homepage = "https://github.com/crate-workbench/cratedb-toolkit"
 repository = "https://github.com/crate-workbench/cratedb-toolkit"
 [project.scripts]
+cratedb-cfr = "cratedb_toolkit.cfr.cli:cli"
 cratedb-retention = "cratedb_toolkit.retention.cli:cli"
 cratedb-toolkit = "cratedb_toolkit.cli:cli"
 cratedb-wtf = "cratedb_toolkit.wtf.cli:cli"
@@ -355,3 +359,5 @@ release = [
 ]
 
 test = { cmd = "pytest" }
+
+build-cfr = { cmd = "pyinstaller cratedb_toolkit/cfr/cli.py --onefile --name cratedb-cfr"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ release = [
   "twine<6",
 ]
 release-cfr = [
+  "poethepoet<0.28",
   "pyinstaller<7",
 ]
 service = [


### PR DESCRIPTION
## About
Use [PyInstaller](https://pyinstaller.org/) to build self-contained application bundles of the [CrateDB Cluster Flight Recorder (CFR)](https://cratedb-toolkit.readthedocs.io/cfr/).

- GH-160

## Preview
See section "Artifacts » Produced during runtime" on [GHA run #9826830191](https://github.com/crate-workbench/cratedb-toolkit/actions/runs/9826830191).
