### PR TITLE
IO: Add the `if-exists` query parameter by updating to influxio 0.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- IO: Added the `if-exists` query parameter by updating to influxio 0.4.0.
 
 ## 2024/06/18 v0.0.14
 - Add `ctk cfr` and `ctk wtf` diagnostics programs

--- a/doc/io/influxdb/loader.md
+++ b/doc/io/influxdb/loader.md
@@ -16,7 +16,7 @@ working with InfluxDB.
 pip install --upgrade 'cratedb-toolkit[influxdb]'
 ```
 
-## Examples
+## Usage
 
 ### Workstation
 
@@ -64,6 +64,27 @@ connection URLs.
 ctk load table \
   "influxdb2://9fafc869a91a3517:T268DVLDHD8...oPic4A==@eu-central-1-1.aws.cloud2.influxdata.com/testdrive/demo?ssl=true" \
   --cratedb-sqlalchemy-url="crate://admin:dZ...6LqB@green-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200/testdrive/demo?ssl=true"
+```
+
+## Parameters
+
+### `if-exists`
+
+The target table will be created automatically, if it does not exist. If it
+does exist, the `if-exists` URL query parameter can be used to configure this
+behavior. The default value is `fail`, the possible values are:
+
+* `fail`: Raise a ValueError.
+* `replace`: Drop the table before inserting new values.
+* `append`: Insert new values to the existing table.
+
+:::{rubric} Example usage
+:::
+In order to always replace the target table, i.e. to drop and re-create it
+prior to inserting data, use `?if-exists=replace`.
+```shell
+export CRATEDB_SQLALCHEMY_URL="crate://crate@localhost:4200/testdrive/demo?if-exists=replace"
+ctk load table influxdb2://example:token@localhost:8086/testdrive/demo
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ full = [
 ]
 influxdb = [
   "cratedb-toolkit[io]",
-  "influxio>=0.3.1,<1",
+  "influxio>=0.4,<1",
 ]
 io = [
   "cr8",


### PR DESCRIPTION
## Problem
Because the InfluxDB I/O subsystem, implementing `ctk load table influxdb2://...`, always replaced the target table, it could have been considered as "just a toy". Thanks to that discovery by @wierdvanderhaar, we have been able to improve it.

## Solution
The improvement follows the semantics of the [`to_sql()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_sql.html) implementation of pandas/Dask, and now takes a new `if-exists` URL query parameter into consideration, forwarding the possible values `{fail,replace,append}` to the corresponding implementation.

## References
- GH-148
- https://github.com/daq-tools/influxio/pull/129

/cc @matkuliak, @simonprickett
