### PR TITLE
CI: Maintenance, this and that

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/release/oci"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/release-oci.yml
+++ b/.github/workflows/release-oci.yml
@@ -1,5 +1,5 @@
 # Stage OCI container images through GitHub Actions (GHA) to GitHub Container Registry (GHCR).
-name: Release OCI to GHCR
+name: "Release: OCI to GHCR"
 
 on:
   pull_request: ~

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,5 +1,5 @@
 # Stage Python source distribution and wheel packages through GitHub Actions (GHA) to Python Package Index (PyPI).
-name: Release to PyPI
+name: "Release: Python package to PyPI"
 
 on:
   push:


### PR DESCRIPTION
- Increase frequency of Dependabot checks to "weekly".
- Naming things. Use `Release:` prefix for all release jobs.
