### PR TITLE
CFR: Upload application bundle artifacts to GitHub Pages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+cratedb-cfr filter=lfs diff=lfs merge=lfs -text
+cratedb-cfr.exe filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -66,10 +66,15 @@ jobs:
       uses: actions/configure-pages@v3
 
     - name: Upload artifact to GitHub Pages 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: peaceiris/actions-gh-pages@v4
       with:
-        folder: dist
-        target-folder: "tmp/${{ steps.artifact-suffix.outputs.lowercase }}"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: dist
+        destination_dir: "tmp/${{ steps.artifact-suffix.outputs.lowercase }}"
+      #uses: JamesIves/github-pages-deploy-action@v4
+      #with:
+      #  folder: dist
+      #  target-folder: "tmp/${{ steps.artifact-suffix.outputs.lowercase }}"
 
     # TODO: Upload to release assets or GitHub Pages, when invoked on "tag" event.
     #if: startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -62,5 +62,14 @@ jobs:
         name: "cratedb-cfr-${{ steps.artifact-suffix.outputs.lowercase }}"
         path: dist/cratedb-cfr.exe
 
+    - name: Configure GitHub Pages
+      uses: actions/configure-pages@v3
+
+    - name: Upload artifact to GitHub Pages 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: dist
+        target-folder: "tmp/${{ steps.artifact-suffix.outputs.lowercase }}"
+
     # TODO: Upload to release assets or GitHub Pages, when invoked on "tag" event.
     #if: startsWith(github.event.ref, 'refs/tags')


### PR DESCRIPTION
## Problem
Uploading on PRs to GitHub Workflow Artifacts is not enough, because it does not provide good UX for downloading purposes.

## About
This patch extends the GHA workflow to additionally upload to GitHub Pages.

## References
- GH-175
